### PR TITLE
Change Management Adapter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@
 /vendor/github.com/libgit2/git2go/v31/vendor/**
 # slack private conf file
 slack_conf.yaml
+.project

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,7 @@ vet: vendor/github.com/libgit2/git2go/v31/static-build ## Vet heckler, usually c
 
 .PHONY: test
 test: vendor/github.com/libgit2/git2go/v31/static-build ## Test heckler, usually called inside the container
+	go build -o . ./mockups/change_management_system/cmd/mockup-cm-cli
 	go test ./...
 
 vendor/github.com/libgit2/git2go/v31/static-build: ## Build libgit2

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ of node sets which are specified by the user.
 3. Running hecklerd main.go on local mac dev env
 
 	export GO111MODULE=on
-	export CGO_LDFLAGS='-g -O2 -Wl,-rpath,<<local_dev_folder>>/heckler/sub-modules/heckler/vendor/github.com/libgit2/git2go/v31/dynamic-build/install/lib'
-	export PKG_CONFIG_PATH='<<local_dev_folder>>/heckler/sub-modules/heckler/vendor/github.com/libgit2/git2go/v31/dynamic-build/install/lib/pkgconfig'
+	export CGO_LDFLAGS='-g -O2 -Wl,-rpath,<<local_dev_folder>>/heckler/vendor/github.com/libgit2/git2go/v31/dynamic-build/install/lib'
+	export PKG_CONFIG_PATH='<<local_dev_folder>>/heckler/vendor/github.com/libgit2/git2go/v31/dynamic-build/install/lib/pkgconfig'
 
 	go run cmd/hecklerd/main.go  | tee output_`date +%d-%m-%Y-%s`.log

--- a/change_management/adapter/cm_adapter.go
+++ b/change_management/adapter/cm_adapter.go
@@ -1,0 +1,286 @@
+package cm_adapter
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	cm_cli "github.com/braintree/heckler/change_management/agent/cli"
+	cm_itfc "github.com/braintree/heckler/change_management/interfaces"
+	cm_models "github.com/braintree/heckler/change_management/models"
+	"log"
+)
+
+/*
+Converting Generic Interface to ChangeManagementInterface If not through Error
+*/
+func convertIntoCMInterface(cmITFCMGR interface{}) (cm_itfc.ChangeManagementInterface, error) {
+	var emptyItfcMGR cm_itfc.ChangeManagementInterface
+	switch iTypeValue := cmITFCMGR.(type) {
+	case cm_itfc.ChangeManagementInterface:
+
+		fmt.Println("type cm_itfc.ChangeManagementInterface ")
+		vResp, vErr := iTypeValue.Validate()
+		fmt.Println("vResp,vErr", vResp, vErr)
+		return iTypeValue, nil
+	default:
+		msg := fmt.Sprintf("%v is not a cm_itfc.ChangeManagementInterface", iTypeValue)
+		log.Println(msg)
+		return emptyItfcMGR, errors.New(msg)
+
+	}
+
+}
+
+/* This function takes an interface or nil interface, If nil interface is faced it look for CLI AGENT path from config file and check is that cli exists and is valid? */
+func getCMAgent(adapterConfig cm_models.ChangeManagementAdapterConfig, cmITFCMGR interface{}) (cm_itfc.ChangeManagementInterface, error) {
+
+	var emptyCMAgent cm_itfc.ChangeManagementInterface
+	var cmAgent cm_itfc.ChangeManagementInterface
+	var cmAgentError error
+	log.Println("cmITFCMGR is None?::", cmITFCMGR == nil)
+	log.Println("adapterConfig is ::", adapterConfig)
+
+	if cmITFCMGR != nil {
+		log.Println("cmITFCMGR is not None::", adapterConfig.CMConfigPath)
+		cmAgent, cmAgentError = convertIntoCMInterface(cmITFCMGR)
+	} else if adapterConfig.CLIAgentPath != "" {
+		log.Println("CLIAgentPath::", adapterConfig.CLIAgentPath)
+		cmAgent, cmAgentError = cm_cli.GetCMCLIAgent(adapterConfig.CLIAgentPath, adapterConfig.Verbose)
+	}
+	if cmAgentError != nil {
+		log.Println("cmAgentError::", cmAgentError)
+		return emptyCMAgent, cmAgentError
+	}
+	if cmAgent == nil {
+		if adapterConfig.IsMandatory == true {
+			msg := "CM IsMandatory is true but Unable to get ChangeManagement Agent"
+			log.Println(msg)
+			return emptyCMAgent, errors.New(msg)
+		} else {
+			return emptyCMAgent, nil
+		}
+
+	} else {
+		isValidated, vError := cmAgent.Validate()
+		if vError == nil {
+			if isValidated {
+				return cmAgent, nil
+			} else {
+				msg := fmt.Sprintf("cmAgent %v and Validate returns %t", cmAgent, isValidated)
+				log.Println(msg)
+				return emptyCMAgent, errors.New(msg)
+			}
+		} else {
+			msg := fmt.Sprintf("cmAgent %v Not able to call Validate method %t", cmAgent, vError)
+			log.Println(msg)
+			return emptyCMAgent, errors.New(msg)
+		}
+	}
+
+}
+
+/*convert Generic Map into ChangeManagementAdapterConfig struct*/
+func convertAdapterConfig(adpaterConfig map[string]interface{}) (cm_models.ChangeManagementAdapterConfig, error) {
+
+	var emptyConfig cm_models.ChangeManagementAdapterConfig
+	data, dError := json.Marshal(adpaterConfig)
+	if dError != nil {
+		log.Println("DError", dError)
+		return emptyConfig, dError
+	}
+	log.Println("cmAdatperConfig...", string(data))
+	cmAdatperConfig := new(cm_models.ChangeManagementAdapterConfig)
+	cmAdatperConfigError := json.Unmarshal(data, &cmAdatperConfig)
+	log.Println("cmAdatperConfigError...and cmAdatperConfig...", cmAdatperConfigError, cmAdatperConfig)
+	return *cmAdatperConfig, cmAdatperConfigError
+
+}
+
+/*
+CM Adapter struct/class has encapsulated functions to have a loose coupling with(miminum code changes in) hecklerd/main.go
+*/
+type ChangeManagementAdapter struct {
+	cmAgent       cm_itfc.ChangeManagementInterface
+	adapterConfig cm_models.ChangeManagementAdapterConfig
+}
+
+func NewCMAdapter(config map[string]interface{}, cmITFCMGR interface{}) (ChangeManagementAdapter, error) {
+	var cmAdapter ChangeManagementAdapter
+
+	adapterConfig, adapterConfigError := convertAdapterConfig(config)
+	if adapterConfigError != nil {
+		log.Println("adapterConfigError...", adapterConfigError)
+		return cmAdapter, adapterConfigError
+	}
+	agent, agentError := getCMAgent(adapterConfig, cmITFCMGR)
+	if agentError != nil {
+		log.Println("agentError", agentError)
+		return cmAdapter, agentError
+	}
+	cmAdapter = ChangeManagementAdapter{adapterConfig: adapterConfig, cmAgent: agent}
+	return cmAdapter, nil
+
+}
+
+/*
+Get change Request in Json format for a given changeRequest ID
+*/
+func (cmAdapter ChangeManagementAdapter) getChangeRequestDetails(changeRequestID string) (string, error) {
+
+	if changeRequestID == "" {
+		log.Println("GetChangeRequestDetails::changeRequestID is empty")
+		return "", nil
+	}
+	crDetails, crError := cmAdapter.cmAgent.GetChangeRequestDetails(changeRequestID)
+	if crError != nil && cmAdapter.isMandatory() == false {
+		return "", nil
+	}
+	return crDetails, crError
+}
+
+/*
+This function creates a ChangeRequest for given envPrefix and Tag value
+and CheckIn the ChangeRequest with checkin comments
+returns ChangeRequest if Success, proper error in case of error
+*/
+func (cmAdapter ChangeManagementAdapter) CreateAndCheckInCR(envPrefix, nextTag, checkINComments string) (string, bool) {
+
+	if cmAdapter.cmAgent == nil && cmAdapter.isMandatory() == false {
+		log.Println("AS CM is not Mandatory and CMAGent is not configured,..returning empty CR ID")
+		return "", false
+	}
+	changeRequestID, createError := cmAdapter.createChangeRequest(envPrefix, nextTag)
+	log.Printf("CreateChangeRequest Status for %s:: : changeRequestID::%s and  createError::'%v'", nextTag, changeRequestID, createError)
+
+	if createError != nil || changeRequestID == "" {
+		log.Println("had a createCRError or changeRequestID is empty")
+		pauseExecutuion := cmAdapter.getPauseExecutionValue()
+		log.Println("Returns PauseExecution as", pauseExecutuion, " and changeRequestID is Empty")
+		return "", pauseExecutuion
+	}
+	log.Printf("Going for CheckIn the ChangeRequest %s %s", changeRequestID, checkINComments)
+	isCheckedIN, checkinError := cmAdapter.checkInChangeRequest(changeRequestID, checkINComments)
+	log.Printf("CheckInChangeRequest Status: isCheckedIN::%t and  checkinError::'%v'", isCheckedIN, checkinError)
+
+	if checkinError != nil || isCheckedIN == false {
+		log.Println("had a checkinError or isCheckedIN is false")
+		pauseExecutuion := cmAdapter.getPauseExecutionValue()
+		log.Println("Returns PauseExecution as", pauseExecutuion, " and changeRequestID is Empty")
+		return "", pauseExecutuion
+	}
+
+	return changeRequestID, false
+
+}
+
+/* This function decided whether hecklerd/main.go has to skip current puppet apply steps or not
+based upon IsMandatory/onErrorStop config values
+*/
+func (cmAdapter ChangeManagementAdapter) getPauseExecutionValue() bool {
+	if cmAdapter.isMandatory() {
+		log.Println("CM IsMandatory is True,hence getPauseExecutionValue is true")
+		return true
+	} else if cmAdapter.onErrorStop() == true {
+		log.Println("onErrorStop is True so getPauseExecutionValue is true")
+		return true
+	} else {
+		log.Println("onErrorStop is false")
+		return false
+	}
+}
+
+/*
+Create a ChangeRequest, Passing minimum info like
+*/
+func (cmAdapter ChangeManagementAdapter) createChangeRequest(envPrefix, tag string) (string, error) {
+	crID, crError := cmAdapter.cmAgent.CreateChangeRequest(envPrefix, tag)
+	if crError != nil && cmAdapter.isMandatory() == false {
+		log.Println("CreateChangeRequest::IsMandatory is false", crError)
+		return "", nil
+	}
+	return crID, crError
+
+}
+
+/*
+Add a note/comment to a given Change Request
+*/
+func (cmAdapter ChangeManagementAdapter) CommentChangeRequest(changeRequestID, comments string) (bool, error) {
+	if changeRequestID == "" {
+		log.Println("CommentChangeRequest::changeRequestID is empty")
+		return true, nil
+	}
+	log.Printf("changeRequestID %s snowComments %s", changeRequestID, comments)
+	updated, crError := cmAdapter.cmAgent.CommentChangeRequest(changeRequestID, comments)
+
+	if crError != nil && cmAdapter.isMandatory() == false {
+		log.Println("CommentChangeRequest::IsMandatory is false", crError)
+		return true, nil
+	}
+	return updated, crError
+}
+
+/*
+CheckIn the ChangeRequest
+*/
+func (cmAdapter ChangeManagementAdapter) checkInChangeRequest(changeRequestID, comments string) (bool, error) {
+	if changeRequestID == "" {
+		log.Println("CheckInChangeRequest::changeRequestID is empty")
+		return true, nil
+	}
+	updated, crError := cmAdapter.cmAgent.CheckInChangeRequest(changeRequestID, comments)
+	if crError != nil && cmAdapter.isMandatory() == false {
+		log.Println("CheckInChangeRequest::IsMandatory is false", crError)
+		return true, nil
+	}
+	return updated, crError
+}
+
+/*
+Close/SignOff change request
+*/
+func (cmAdapter ChangeManagementAdapter) SignOffChangeRequest(changeRequestID, comments string) (bool, error) {
+	if changeRequestID == "" {
+		log.Println("SignOffChangeRequest::changeRequestID is empty,so no Need of SignOffChangeRequest")
+		return true, nil
+	}
+	isSignedOff, signOffError := cmAdapter.cmAgent.SignOffChangeRequest(changeRequestID, comments)
+	log.Printf("SignOffChangeRequest Status: isSignedOff::%t and  signOffError::'%v'", isSignedOff, signOffError)
+	if signOffError != nil && cmAdapter.isMandatory() == false {
+		log.Println("SignOffChangeRequest::IsMandatory is false", signOffError)
+		return true, nil
+	}
+	return isSignedOff, signOffError
+}
+
+/*
+Check Underlaying Agent is configured properly or not.
+*/
+func (cmAdapter ChangeManagementAdapter) Validate() (bool, error) {
+	if cmAdapter.isMandatory() == false {
+		log.Println("Validate::IsMandatory is false")
+		return true, nil
+	}
+	return cmAdapter.cmAgent.Validate()
+
+}
+
+/*
+If isMandatory is true return true.
+If isMandatory is false then return OnErrorStop config value
+*/
+func (cmAdapter ChangeManagementAdapter) onErrorStop() bool {
+	if cmAdapter.isMandatory() == true {
+		return true
+	} else {
+		log.Println("OnErrorStop::IsMandatory is false so returning ONErrorFail returning configured value")
+
+		return cmAdapter.adapterConfig.OnErrorStop
+	}
+
+}
+
+func (cmAdapter ChangeManagementAdapter) isMandatory() bool {
+	return cmAdapter.adapterConfig.IsMandatory
+
+}

--- a/change_management/agent/cli/cm_cli_agent.go
+++ b/change_management/agent/cli/cm_cli_agent.go
@@ -1,0 +1,330 @@
+package cm_agent_cli
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	cm_models "github.com/braintree/heckler/change_management/models"
+	"io/ioutil"
+	"log"
+	"os"
+	"os/exec"
+)
+
+const DEFAULT_CLI_PATH = "/usr/bin/hecklerd_snow_cli"
+
+type CMCLIAgent struct {
+	cliPath string
+	verbose bool
+}
+
+func GetCMCLIAgent(cliPath string, verbose bool) (CMCLIAgent, error) {
+	if cliPath == "" {
+		log.Println("cliPath is empty hence using default Path::", DEFAULT_CLI_PATH)
+	}
+	var emptyCMCLIAgent CMCLIAgent
+	log.Printf(" cliPath::%s verbose::%t\n", cliPath, verbose)
+	cmCLIAgent := CMCLIAgent{cliPath: cliPath, verbose: verbose}
+
+	isValidated, err := cmCLIAgent.Validate()
+	if err != nil || isValidated == false {
+
+		if isValidated == false {
+			msg := fmt.Sprintf("Unable  validate CLI ::%s", cliPath)
+			log.Println("error:msg", msg)
+			err = errors.New(msg)
+		} else {
+			log.Printf("cli.Open error::%v \n", err)
+		}
+		return emptyCMCLIAgent, err
+	} else {
+		log.Println("Cli is validated", isValidated)
+	}
+
+	return cmCLIAgent, nil
+}
+
+func (cmCLIAgent CMCLIAgent) process(arguments ...string) (int, cm_models.CMResponsePayLoad, error) {
+	fmt.Println("inside process")
+	var emtpyResponse cm_models.CMResponsePayLoad
+	path, err := exec.LookPath(cmCLIAgent.cliPath)
+	fmt.Println(path, err)
+	var outputFile string
+	jsonFile, fileError := ioutil.TempFile("/tmp", "heckler_cm_cli_output"+".*.json")
+	if fileError != nil {
+		log.Println(fileError)
+		return LOCAL_RUNTIME_ERROR_CODE, emtpyResponse, fileError
+	} else {
+		defer os.Remove(jsonFile.Name())
+		outputFile = jsonFile.Name()
+	}
+	arguments = append(arguments, getOutputFileFlag(outputFile))
+	arguments = append(arguments, getVerboseFlag(true))
+	cmd := exec.Command(cmCLIAgent.cliPath, arguments...)
+	// 	 getOutputFileFlag(outputFile), getVerboseFlag(true))
+	// 	stdout, err := cmd.Output()
+	var outb, errb bytes.Buffer
+	cmd.Stdout = &outb
+	cmd.Stderr = &errb
+	err = cmd.Run()
+	log.Println("output", outb.String())
+	log.Println("Stderr...", cmd.Stderr)
+	responseJson, responseError := getResponseJson(outputFile, outb)
+	log.Println(responseJson, responseError)
+	exitCode := getExitCodeOrPathError(err)
+	log.Println("ExitCode::", exitCode)
+
+	if exitCode == 0 {
+		log.Println("exit code is zero,Call is success")
+	} else if exitCode == 1 {
+		log.Println("empty Response ERROR Code::", exitCode)
+	} else if exitCode == 3 {
+		log.Println("output generation ERROR Code::", exitCode)
+	} else if exitCode == 2 {
+		log.Println("GSNOW ERROR Code::", exitCode)
+	} else if exitCode == -1 || exitCode == -2 {
+		log.Println("Unknown Exist Code::", exitCode)
+	}
+
+	return exitCode, responseJson, responseError
+}
+func (cmCLIAgent CMCLIAgent) Validate() (bool, error) {
+	arguments := []string{getCommandFlag("Validate")}
+	exitCode, responseJson, responseError := cmCLIAgent.process(arguments...)
+	if exitCode == 0 {
+		log.Println("exit code is zero,Call is success")
+		return true, nil
+	} else {
+		log.Println("responseJson, responseError", responseJson, responseError)
+		return false, nil
+	}
+}
+
+func (cmCLIAgent CMCLIAgent) SearchChangeRequest(envPrefix, tagValue string) (string, error) {
+
+	log.Println("inside SearchChangeRequest", envPrefix, tagValue)
+	arguments := []string{getCommandFlag("SearchChangeRequest"), getEnvPrefixFlag(envPrefix), getTagFlag(tagValue), getVerboseFlag(cmCLIAgent.verbose)}
+	exitCode, responseJson, responseError := cmCLIAgent.process(arguments...)
+	if exitCode == 0 {
+		log.Println("exit code is zero,Call is success", responseJson.CRResult.ChangeRequestID)
+		if responseJson.Status == cm_models.STATUS_SUCCESS {
+			return responseJson.CRResult.ChangeRequestID, nil
+		} else {
+			log.Println("responseJson.Error.Message..", responseJson.Error.Message)
+			return "", errors.New(responseJson.Error.Message)
+		}
+	} else {
+		log.Println("responseJson, responseError", responseJson, responseError)
+		if responseJson.Status == cm_models.STATUS_FAILURE {
+			log.Println("responseJson.Error.Message..", responseJson.Error.Message)
+			return "", errors.New(responseJson.Error.Message)
+		} else {
+			msg := fmt.Sprintf("Exit Code(%d) is not Zero", exitCode)
+			log.Println("msg...", msg)
+			return "", errors.New(msg)
+		}
+	}
+}
+
+func (cmCLIAgent CMCLIAgent) SearchAndCreateChangeRequest(envPrefix, tagValue string) (string, error) {
+
+	log.Println("inside SearchAndCreateChangeRequest", envPrefix, tagValue)
+	arguments := []string{getCommandFlag("SearchAndCreateChangeRequest"), getEnvPrefixFlag(envPrefix), getTagFlag(tagValue), getVerboseFlag(cmCLIAgent.verbose)}
+	exitCode, responseJson, responseError := cmCLIAgent.process(arguments...)
+	if exitCode == 0 {
+		log.Println("exit code is zero,Call is success", responseJson.CRResult.ChangeRequestID)
+		if responseJson.Status == cm_models.STATUS_SUCCESS {
+			return responseJson.CRResult.ChangeRequestID, nil
+		} else {
+			log.Println("responseJson.Error.Message..", responseJson.Error.Message)
+			return "", errors.New(responseJson.Error.Message)
+		}
+	} else {
+		log.Println("responseJson, responseError", responseJson, responseError)
+		if responseJson.Status == cm_models.STATUS_FAILURE {
+			log.Println("responseJson.Error.Message..", responseJson.Error.Message)
+			return "", errors.New(responseJson.Error.Message)
+		} else {
+			msg := fmt.Sprintf("Exit Code(%d) is not Zero", exitCode)
+			log.Println("msg...", msg)
+			return "", errors.New(msg)
+		}
+	}
+}
+
+func (cmCLIAgent CMCLIAgent) CreateChangeRequest(envPrefix, tagValue string) (string, error) {
+
+	log.Println("inside CreateChangeRequest", envPrefix, tagValue)
+	arguments := []string{getCommandFlag("CreateChangeRequest"), getEnvPrefixFlag(envPrefix), getTagFlag(tagValue), getVerboseFlag(cmCLIAgent.verbose)}
+	exitCode, responseJson, responseError := cmCLIAgent.process(arguments...)
+	if exitCode == 0 {
+		log.Println("exit code is zero,Call is success", responseJson.CRResult.ChangeRequestID)
+		if responseJson.Status == cm_models.STATUS_SUCCESS {
+			return responseJson.CRResult.ChangeRequestID, nil
+		} else {
+			log.Println("responseJson.Error.Message..", responseJson.Error.Message)
+			return "", errors.New(responseJson.Error.Message)
+		}
+	} else {
+		log.Println("responseJson, responseError", responseJson, responseError)
+		if responseJson.Status == cm_models.STATUS_FAILURE {
+			log.Println("responseJson.Error.Message..", responseJson.Error.Message)
+			return "", errors.New(responseJson.Error.Message)
+		} else {
+			msg := fmt.Sprintf("Exit Code(%d) is not Zero", exitCode)
+			log.Println("msg...", msg)
+			return "", errors.New(msg)
+		}
+	}
+}
+func (cmCLIAgent CMCLIAgent) GetChangeRequestDetails(changeRequestID string) (string, error) {
+
+	log.Println("inside GetChangeRequestDetails", changeRequestID)
+
+	arguments := []string{getCommandFlag("GetChangeRequestDetails"), getChangeRequestIDFlag(changeRequestID), getVerboseFlag(cmCLIAgent.verbose)}
+	exitCode, responseJson, responseError := cmCLIAgent.process(arguments...)
+	if exitCode == 0 {
+		log.Println("exit code is zero,Call is success")
+		if responseJson.Status == cm_models.STATUS_SUCCESS {
+			return responseJson.CRResult.CRDetails, nil
+		} else {
+			log.Println("responseJson.Error.Message..", responseJson.Error.Message)
+			return "", errors.New(responseJson.Error.Message)
+		}
+	} else {
+		log.Println("responseJson, responseError", responseJson, responseError)
+		if responseJson.Status == cm_models.STATUS_FAILURE {
+			log.Println("responseJson.Error.Message..", responseJson.Error.Message)
+			return "", errors.New(responseJson.Error.Message)
+		} else {
+			msg := fmt.Sprintf("Exit Code(%d) is not Zero", exitCode)
+			log.Println("msg...", msg)
+			return "", errors.New(msg)
+		}
+	}
+
+}
+
+func (cmCLIAgent CMCLIAgent) CommentChangeRequest(changeRequestID, comments string) (bool, error) {
+
+	log.Println("inside CommentChangeRequest", changeRequestID, comments)
+
+	arguments := []string{getCommandFlag("CommentChangeRequest"), getChangeRequestIDFlag(changeRequestID), getCommentsFlag(comments), getVerboseFlag(cmCLIAgent.verbose)}
+	exitCode, responseJson, responseError := cmCLIAgent.process(arguments...)
+	if exitCode == 0 {
+		log.Println("exit code is zero,Call is success", responseJson.CRActionResult.Message)
+		if responseJson.Status == cm_models.STATUS_SUCCESS {
+			return true, nil
+		} else {
+			log.Println("responseJson.Error.Message..", responseJson.Error.Message)
+			return false, errors.New(responseJson.Error.Message)
+		}
+	} else {
+		log.Println("responseJson, responseError", responseJson, responseError)
+		if responseJson.Status == cm_models.STATUS_FAILURE {
+			log.Println("responseJson.Error.Message..", responseJson.Error.Message)
+			return false, errors.New(responseJson.Error.Message)
+		} else {
+			msg := fmt.Sprintf("Exit Code(%d) is not Zero", exitCode)
+			log.Println("msg...", msg)
+			return false, errors.New(msg)
+		}
+	}
+
+}
+
+func (cmCLIAgent CMCLIAgent) CheckInChangeRequest(changeRequestID, comments string) (bool, error) {
+
+	log.Println("inside CheckInChangeRequest", changeRequestID, comments)
+
+	arguments := []string{getCommandFlag("CheckInChangeRequest"), getChangeRequestIDFlag(changeRequestID), getCommentsFlag(comments), getVerboseFlag(cmCLIAgent.verbose)}
+	exitCode, responseJson, responseError := cmCLIAgent.process(arguments...)
+	if exitCode == 0 {
+		log.Println("exit code is zero,Call is success", responseJson.CRActionResult.Message)
+		if responseJson.Status == cm_models.STATUS_SUCCESS {
+			return true, nil
+		} else {
+			log.Println("responseJson.Error.Message..", responseJson.Error.Message)
+			return false, errors.New(responseJson.Error.Message)
+		}
+	} else {
+		log.Println("responseJson, responseError", responseJson, responseError)
+		if responseJson.Status == cm_models.STATUS_FAILURE {
+			log.Println("responseJson.Error.Message..", responseJson.Error.Message)
+			return false, errors.New(responseJson.Error.Message)
+		} else {
+			msg := fmt.Sprintf("Exit Code(%d) is not Zero", exitCode)
+			log.Println("msg...", msg)
+			return false, errors.New(msg)
+		}
+	}
+
+}
+
+func (cmCLIAgent CMCLIAgent) ReviewChangeRequest(changeRequestID, comments string) (bool, error) {
+	log.Println("inside ReviewChangeRequest", changeRequestID, comments)
+
+	arguments := []string{getCommandFlag("ReviewChangeRequest"), getChangeRequestIDFlag(changeRequestID), getCommentsFlag(comments), getVerboseFlag(cmCLIAgent.verbose)}
+	exitCode, responseJson, responseError := cmCLIAgent.process(arguments...)
+	if exitCode == 0 {
+		log.Println("exit code is zero,Call is success", responseJson.CRActionResult.Message)
+		if responseJson.Status == cm_models.STATUS_SUCCESS {
+			return true, nil
+		} else {
+			log.Println("responseJson.Error.Message..", responseJson.Error.Message)
+			return false, errors.New(responseJson.Error.Message)
+		}
+	} else {
+		log.Println("responseJson, responseError", responseJson, responseError)
+		if responseJson.Status == cm_models.STATUS_FAILURE {
+			log.Println("responseJson.Error.Message..", responseJson.Error.Message)
+			return false, errors.New(responseJson.Error.Message)
+		} else {
+			msg := fmt.Sprintf("Exit Code(%d) is not Zero", exitCode)
+			log.Println("msg...", msg)
+			return false, errors.New(msg)
+		}
+	}
+}
+func (cmCLIAgent CMCLIAgent) SignOffChangeRequest(changeRequestID, comments string) (bool, error) {
+
+	log.Println("inside SignOffChangeRequest", changeRequestID, comments)
+
+	arguments := []string{getCommandFlag("SignOffChangeRequest"), getChangeRequestIDFlag(changeRequestID), getCommentsFlag(comments), getVerboseFlag(cmCLIAgent.verbose)}
+	exitCode, responseJson, responseError := cmCLIAgent.process(arguments...)
+	if exitCode == 0 {
+		log.Println("exit code is zero,Call is success", responseJson.CRActionResult.Message)
+		if responseJson.Status == cm_models.STATUS_SUCCESS {
+			return true, nil
+		} else {
+			log.Println("responseJson.Error.Message..", responseJson.Error.Message)
+			return false, errors.New(responseJson.Error.Message)
+		}
+	} else {
+		log.Println("responseJson, responseError", responseJson, responseError)
+		if responseJson.Status == cm_models.STATUS_FAILURE {
+			log.Println("responseJson.Error.Message..", responseJson.Error.Message)
+			return false, errors.New(responseJson.Error.Message)
+		} else {
+			msg := fmt.Sprintf("Exit Code(%d) is not Zero", exitCode)
+			log.Println("msg...", msg)
+			return false, errors.New(msg)
+		}
+	}
+}
+
+func getEnvPrefixFlag(envPrefix string) string   { return "-env_prefix=" + envPrefix }
+func getTagFlag(tagValue string) string          { return "-tag=" + tagValue }
+func getCommentsFlag(comments string) string     { return "-comments=" + comments }
+func getCommandFlag(command string) string       { return "-command=" + command }
+func getOutputFileFlag(outputFile string) string { return "-output_file=" + outputFile }
+func getChangeRequestIDFlag(changeRequestID string) string {
+	return "-change_request_id=" + changeRequestID
+}
+func getVerboseFlag(verbose bool) string {
+	if verbose {
+		return "-verbose=true"
+	} else {
+		return "-verbose=false"
+	}
+}

--- a/change_management/agent/cli/response_functions.go
+++ b/change_management/agent/cli/response_functions.go
@@ -1,0 +1,55 @@
+package cm_agent_cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	cm_models "github.com/braintree/heckler/change_management/models"
+	"log"
+	"os"
+	"os/exec"
+)
+
+const PATH_ERROR_CODE = -1
+const LOCAL_RUNTIME_ERROR_CODE = -99
+
+func getExitCodeOrPathError(err error) int {
+	var exitError *exec.ExitError
+	var pathError *os.PathError
+	if errors.As(err, &exitError) {
+		if exitError.ExitCode() == 1 {
+			return 1
+		} else if exitError.ExitCode() == 2 {
+			return 2
+		} else {
+			return exitError.ExitCode()
+		}
+	} else if errors.As(err, &pathError) {
+		log.Println("pathError ,return ExitCode as -1", pathError)
+		return PATH_ERROR_CODE
+	} else if err != nil {
+		log.Println("Unknown Error, Not able to determine ExitCode,return ExitCode as -2")
+		return -2
+	} else {
+		return 0
+	}
+}
+
+func getResponseJson(outputFile string, outb bytes.Buffer) (cm_models.CMResponsePayLoad, error) {
+	var responseJson string
+	var emptyCMResponse cm_models.CMResponsePayLoad
+	cmResponse := new(cm_models.CMResponsePayLoad)
+	if outputFile == "" {
+		responseJson = outb.String()
+	} else {
+		outputBytes, readError := os.ReadFile(outputFile)
+		if readError == nil {
+			responseJson = string(outputBytes)
+		} else {
+			return emptyCMResponse, readError
+		}
+	}
+
+	err := json.Unmarshal([]byte(responseJson), cmResponse)
+	return *cmResponse, err
+}

--- a/change_management/interfaces/cm_interface.go
+++ b/change_management/interfaces/cm_interface.go
@@ -1,0 +1,27 @@
+package cm_interfaces
+
+/*
+This is interface with set of functions of a ChangeRequest
+ChangeManagement implementation class (cli/structs/plugin) should have these methods.
+
+*/
+type ChangeManagementInterface interface {
+	/* Takes 2 inputs env_prefix from hecklerd_conf.yaml and tag/release value
+	and findouts any existing active ChangeRequest is available to resuse it */
+	SearchChangeRequest(env_prefix, tag string) (string, error)
+	/* Takes 2 inputs env_prefix from hecklerd_conf.yaml and tag/release value
+	and creates a new ChangeRequest  */
+	CreateChangeRequest(env_prefix, tag string) (string, error)
+	/* Takes changeRequestID as input and returns ChangeRequest details(json format)  */
+	GetChangeRequestDetails(changeRequestID string) (string, error)
+	/* Takes changeRequestID and a comment as input and update the change request with given comments ,returns updated/or not  */
+	CommentChangeRequest(changeRequestID, comments string) (bool, error)
+	/* Takes changeRequestID and a checkin comment as input and check ins the change request with given comments ,returns is_checkedIn/or not  */
+	CheckInChangeRequest(changeRequestID, comments string) (bool, error)
+	/* Takes changeRequestID and a sign Off comment as input and signOff the change request with given comments ,returns is_signedOff/or not  */
+	SignOffChangeRequest(changeRequestID, comments string) (bool, error)
+	/* Takes changeRequestID and a review comment as input and moves the change request to review state with given comments ,returns is_status moved to review state/or not  */
+	ReviewChangeRequest(changeRequestID, comments string) (bool, error)
+	/* self validate method to check implementation class/structs is configured properly and good to use it */
+	Validate() (bool, error)
+}

--- a/change_management/models/cm_models.go
+++ b/change_management/models/cm_models.go
@@ -1,0 +1,38 @@
+package change_management
+
+const STATUS_FAILURE = "failure"
+const STATUS_SUCCESS = "success"
+
+/* CM CLI provider returns/writes output of interaction in json/yaml format and below types are models
+for Error/Result types
+*/
+type ErrorType struct {
+	Message string `yaml:"message" json:"message,omitempty"`
+	Detail  string `yaml:"detail" json:"detail,omitempty"`
+}
+
+type CRActionResultType struct {
+	ChangeRequestID string `yaml:"change_request_id" json:"change_request_id,omitempty"`
+	Message         string `yaml:"message" json:"message,omitempty"`
+}
+type CRResultType struct {
+	ChangeRequestID string `yaml:"change_request_id" json:"change_request_id,omitempty"`
+	CRDetails       string `yaml:"cr_details" json:"cr_details,omitempty"`
+}
+type CMResponsePayLoad struct {
+	CRResult       CRResultType       `yaml:"change_request_result" json:"change_request_result,omitempty"`
+	CRActionResult CRActionResultType `yaml:"change_request_action_result" json:"change_request_action_result,omitempty"`
+	Error          ErrorType          `yaml:"error" json:"error,omitempty"`
+	Status         string             `yaml:"status" json:"status,omitempty"`
+}
+
+/*
+Config for Change Management Adapter, these configs are part of hecklerd_conf.yaml
+*/
+type ChangeManagementAdapterConfig struct {
+	OnErrorStop  bool   `default:"false" yaml:"on_error_stop" json:"on_error_stop"`
+	IsMandatory  bool   `default:"false" yaml:"is_mandatory" json:"is_mandatory"`
+	CMConfigPath string `yaml:"cm_config_path" json:"cm_config_path"`
+	CLIAgentPath string `yaml:"cli_agent_path" json:"cli_agent_path"`
+	Verbose      bool   `default:"true" yaml:"verbose" json:"verbose"`
+}

--- a/doc/sample-configs/hecklerd_conf.yaml
+++ b/doc/sample-configs/hecklerd_conf.yaml
@@ -32,6 +32,12 @@ ignored_resources:
     resources:
       - type: 'File'
         title: '/data/puppet_apply/statler/wit'
+change_management_adapter_config:
+  cli_agent_path: '/usr/local/bin/heckler-cm-cli'
+  cm_config_path: '/etc/hecklerd/cm_config_conf.yaml'
+  is_mandatory: true
+  on_error_stop: true
+  verboase: true
 node_sets:
   all:
     cmd:

--- a/go.mod
+++ b/go.mod
@@ -31,3 +31,5 @@ require (
 	google.golang.org/grpc v1.28.1
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c
 )
+
+replace github.com/braintree/heckler => ../heckler

--- a/mockups/change_management_system/client/mockup_cms_client.go
+++ b/mockups/change_management_system/client/mockup_cms_client.go
@@ -1,0 +1,57 @@
+package mockup_itfc_manager
+
+/*Change Management System Client
+Mockup Client to imitate ServiceNow/JIRA  REST APIs Client
+
+MockupCMITFCManager is using this class internaly to invoke actual CMS APIS
+*/
+type MockupCMSClient struct {
+}
+
+func GetMockupCMSClient() (MockupCMSClient, error) {
+	cmsClient := MockupCMSClient{}
+	return cmsClient, nil
+}
+
+func (mcmsClient MockupCMSClient) GetChangeRequestDetails(changeRequestID string) (map[string]interface{}, error) {
+	data := make(map[string]interface{})
+	data["Number"] = "MOCKUPCMTICKET123"
+	return data, nil
+
+}
+
+func (mcmsClient MockupCMSClient) SearchChangeRequestDetails(cmEnvironment, isActive, description, tag string) ([]map[string]interface{}, error) {
+	data := make(map[string]interface{})
+	data["Number"] = "MOCKUPCMTICKET123"
+	var datas []map[string]interface{}
+	datas = append(datas, data)
+	return datas, nil
+}
+
+func (mcmsClient MockupCMSClient) CreateChangeRequest(changeRequestInput map[string]interface{}) (bool, string, error) {
+
+	return true, "MOCKUPCMTICKET123", nil
+}
+
+func (mcmsClient MockupCMSClient) UpdateChangeRequest(changeRequestNo, workNotes string) (bool, error) {
+	return true, nil
+}
+
+func (mcmsClient MockupCMSClient) ReviewChangeRequest(changeTicketNo, workNotes string) (bool, error) {
+
+	return true, nil
+}
+
+func (mcmsClient MockupCMSClient) CheckInChangeRequest(changeTicketNo, workNotes, state string) (bool, error) {
+	return true, nil
+
+}
+
+func (mcmsClient MockupCMSClient) SignOffChangeRequest(changeRequestNo, workNotes, closeNotes, closeCode, state string) (bool, error) {
+	return true, nil
+}
+
+func (mcmsClient MockupCMSClient) SignoffChangeTask(parentID, taskNo, workNotes, state string) (bool, error) {
+	return true, nil
+
+}

--- a/mockups/change_management_system/cmd/mockup-cm-cli/main.go
+++ b/mockups/change_management_system/cmd/mockup-cm-cli/main.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	cm_cli_provider "github.com/braintree/heckler/mockups/change_management_system/provider/cli"
+	"io/ioutil"
+	"log"
+	"os"
+	"strings"
+)
+
+/*
+mockup-cm-cli/main.go is used to build  CLI binary application.
+Its wrapper on top of cm_cli_provider.MockupCMCLIProvider with flags and validate command and inputs passed.
+Commands/Input fields are valid, it will call respective cm_cli_provider functions. Respective function will log output in stdout or to a file.
+*/
+func main() {
+
+	var command string
+	var changeRequestID string
+	var outputFile string
+	var envPrefix string
+	var tag string
+	var comments string
+	var cmConfigPath string
+	var verbose bool
+	cmConfigPath = os.Getenv("CM_CONFIG_PATH")
+	flag.StringVar(&command, "command", "", "Please provide command URL for mockup")
+	flag.StringVar(&outputFile, "output_file", "", "Please provide output file path")
+	flag.StringVar(&envPrefix, "env_prefix", "", "Please provide env")
+	flag.StringVar(&tag, "tag", "", "Please provide tag")
+	flag.StringVar(&comments, "comments", "", "Please provide comments")
+	flag.StringVar(&changeRequestID, "change_request_id", "", "Please provide mockup change request id")
+	flag.StringVar(&cmConfigPath, "cm_config_path", cmConfigPath, "Please provide cm config Path to override")
+	flag.BoolVar(&verbose, "verbose", false, "Please provide verbose as true/false")
+
+	flag.Parse()
+	command = strings.Trim(command, " ")
+	outputFile = strings.Trim(outputFile, " ")
+	envPrefix = strings.Trim(envPrefix, " ")
+	tag = strings.Trim(tag, " ")
+	comments = strings.Trim(comments, " ")
+	if verbose == false {
+		log.SetOutput(ioutil.Discard)
+	} else {
+		log.SetFlags(log.LstdFlags | log.Lshortfile)
+		log.SetOutput(os.Stderr)
+	}
+
+	validateFlagsAndExit(command, envPrefix, tag, changeRequestID, comments)
+
+	cliProvider, initError := cm_cli_provider.GetMockupCMCLIProvider(cmConfigPath)
+	if initError != nil {
+		log.Printf("Error GetBTCMManager err::%v", initError)
+		os.Exit(1)
+	}
+
+	var response string
+	var respError, outputError error
+	switch command {
+	case "SearchChangeRequest":
+		response, respError, outputError = cliProvider.SearchChangeRequest(envPrefix, tag, outputFile)
+	case "SearchAndCreateChangeRequest":
+		response, respError, outputError = cliProvider.SearchAndCreateChangeRequest(envPrefix, tag, outputFile)
+	case "CreateChangeRequest":
+		response, respError, outputError = cliProvider.CreateChangeRequest(envPrefix, tag, outputFile)
+	case "CommentChangeRequest":
+		response, respError, outputError = cliProvider.CommentChangeRequest(changeRequestID, comments, outputFile)
+	case "CheckInChangeRequest":
+		response, respError, outputError = cliProvider.CheckInChangeRequest(changeRequestID, comments, outputFile)
+	case "SignOffChangeRequest":
+		response, respError, outputError = cliProvider.SignOffChangeRequest(changeRequestID, comments, outputFile)
+	case "ReviewChangeRequest":
+		response, respError, outputError = cliProvider.ReviewChangeRequest(changeRequestID, comments, outputFile)
+	case "GetChangeRequestDetails":
+		response, respError, outputError = cliProvider.GetChangeRequestDetails(changeRequestID, outputFile)
+
+	case "Validate":
+		response, respError, outputError = cliProvider.Validate(outputFile)
+	}
+	log.Println("response::", response, "respError::", respError, "outputError::", outputError)
+	if respError != nil {
+		os.Exit(2)
+	} else if outputError != nil {
+		os.Exit(3)
+	} else if response == "" {
+		os.Exit(1)
+	} else {
+		os.Exit(0)
+	}
+
+}
+func validateFlagsAndExit(command, envPrefix, tag, changeRequestID, comments string) {
+	switch command {
+	case "":
+		fmt.Println("command cannot be empty")
+	case "Validate":
+		fmt.Println("command is Validation ")
+		return
+	case "SearchChangeRequest", "SearchAndCreateChangeRequest", "CreateChangeRequest":
+		if tag == "" {
+			fmt.Printf("For command::%s, Env/Tag cannot be empty. env_prefix::'%s' and tag:: '%s'\n", command, envPrefix, tag)
+		} else {
+			return
+		}
+	case "GetChangeRequestDetails":
+		if changeRequestID == "" {
+			fmt.Printf("For command::%s, changeRequestID cannot be empty. changeRequestID::'%s'\n", command, changeRequestID)
+		} else {
+			return
+		}
+
+	case "CommentChangeRequest", "CheckInChangeRequest", "SignOffChangeRequest", "ReviewChangeRequest":
+		if changeRequestID == "" || comments == "" {
+			fmt.Printf("For command::%s, changeRequestID/comments cannot be empty. changeRequestID::'%s' and comments:: '%s'\n", command, changeRequestID, comments)
+		} else {
+			return
+		}
+
+	}
+
+	fmt.Println("validation is failed and exiting")
+	flag.Usage()
+	os.Exit(1)
+}

--- a/mockups/change_management_system/provider/cli/mockup_cm_cli_provider.go
+++ b/mockups/change_management_system/provider/cli/mockup_cm_cli_provider.go
@@ -1,0 +1,266 @@
+package mockup_cli_cm
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	mockup_itfc_manager "github.com/braintree/heckler/mockups/change_management_system/provider/manager"
+
+	cm_models "github.com/braintree/heckler/change_management/models"
+	"gopkg.in/yaml.v3"
+	"log"
+	"os"
+)
+
+/*
+MockupCMCLIProvider has actual logic calling CM Interface Manager
+It provides option to write output to temporary text file
+*/
+type MockupCMCLIProvider struct {
+	cmITFCMGR mockup_itfc_manager.MockupCMITFCManager
+	isValid   bool
+}
+
+func GetMockupCMCLIProvider(cmCFGPath string) (MockupCMCLIProvider, error) {
+	var emptyMockupCMCLIProvider MockupCMCLIProvider
+	cmITFCMGR, initError := mockup_itfc_manager.GetMockupCMITFCManager(cmCFGPath)
+	if initError == nil {
+		return MockupCMCLIProvider{cmITFCMGR: cmITFCMGR, isValid: true}, nil
+	} else {
+		return emptyMockupCMCLIProvider, initError
+	}
+
+}
+
+func (cliProvider MockupCMCLIProvider) SearchChangeRequest(envPrefix, tag, outputFile string) (string, error, error) {
+	var response string
+	var outputError error
+	changeRequestID, searchError := cliProvider.cmITFCMGR.SearchChangeRequest(envPrefix, tag)
+	if searchError != nil {
+		response, outputError = cliProvider.generateErrorMessage(searchError, outputFile)
+	} else {
+		if changeRequestID == "" {
+			response, outputError = cliProvider.generateErrorMessage(errors.New("ChangeRequestID is None"), outputFile)
+
+		} else {
+			response, outputError = cliProvider.generateCRResultMessage(changeRequestID, "", outputFile)
+		}
+	}
+	return response, searchError, outputError
+}
+func (cliProvider MockupCMCLIProvider) SearchAndCreateChangeRequest(envPrefix, tag, outputFile string) (string, error, error) {
+	var response string
+	var outputError error
+	changeRequestID, searchError := cliProvider.cmITFCMGR.SearchAndCreateChangeRequest(envPrefix, tag)
+	if searchError != nil {
+		response, outputError = cliProvider.generateErrorMessage(searchError, outputFile)
+	} else {
+		if changeRequestID == "" {
+			response, outputError = cliProvider.generateErrorMessage(errors.New("ChangeRequestID is None"), outputFile)
+
+		} else {
+			response, outputError = cliProvider.generateCRResultMessage(changeRequestID, "", outputFile)
+		}
+	}
+
+	return response, searchError, outputError
+}
+
+func (cliProvider MockupCMCLIProvider) CreateChangeRequest(envPrefix, tag, outputFile string) (string, error, error) {
+	var response string
+	var outputError error
+	changeRequestID, createError := cliProvider.cmITFCMGR.CreateChangeRequest(envPrefix, tag)
+	log.Println("changeRequestID is ", changeRequestID)
+	log.Println("createError::", createError)
+	if createError != nil {
+		response, outputError = cliProvider.generateErrorMessage(createError, outputFile)
+	} else {
+		if changeRequestID == "" {
+			response, outputError = cliProvider.generateErrorMessage(errors.New("ChangeRequestID is None"), outputFile)
+
+		} else {
+			response, outputError = cliProvider.generateCRResultMessage(changeRequestID, "", outputFile)
+		}
+	}
+	return response, createError, outputError
+}
+func (cliProvider MockupCMCLIProvider) GetChangeRequestDetails(changeRequestID, outputFile string) (string, error, error) {
+	var response string
+	var outputError error
+	crDetails, crErr := cliProvider.cmITFCMGR.GetChangeRequestDetails(changeRequestID)
+	log.Println("crErr::", crErr)
+	log.Println("crDetails is ", crDetails)
+	if crErr != nil {
+		response, outputError = cliProvider.generateErrorMessage(crErr, outputFile)
+	} else {
+		if crDetails == "" {
+			response, outputError = cliProvider.generateErrorMessage(errors.New("ChangeRequest Details is None"), outputFile)
+
+		} else {
+			response, outputError = cliProvider.generateCRResultMessage(changeRequestID, crDetails, outputFile)
+		}
+	}
+
+	return response, crErr, outputError
+}
+func (cliProvider MockupCMCLIProvider) CommentChangeRequest(changeRequestID, comments, outputFile string) (string, error, error) {
+	var response string
+	var outputError error
+	isUpdated, commentError := cliProvider.cmITFCMGR.CommentChangeRequest(changeRequestID, comments)
+	log.Println("isUpdated is ", isUpdated)
+	log.Println("commentError::", commentError)
+	if commentError != nil {
+		response, outputError = cliProvider.generateErrorMessage(commentError, outputFile)
+	} else {
+		if isUpdated {
+			msg := fmt.Sprintf("'%s' comments added to ChangeRequest::%s", comments, changeRequestID)
+			response, outputError = cliProvider.generateCRActionResultMessage(changeRequestID, msg, outputFile)
+		} else {
+			response, outputError = cliProvider.generateErrorMessage(errors.New("Unable provide comments to the Change Request"), outputFile)
+		}
+	}
+	return response, commentError, outputError
+}
+
+func (cliProvider MockupCMCLIProvider) CheckInChangeRequest(changeRequestID, comments, outputFile string) (string, error, error) {
+	var response string
+	var outputError error
+	isCheckedIN, checkINError := cliProvider.cmITFCMGR.CheckInChangeRequest(changeRequestID, comments)
+	log.Println("isCheckedIN is ", isCheckedIN)
+	log.Println("checkINError::", checkINError)
+	if checkINError != nil {
+		response, outputError = cliProvider.generateErrorMessage(checkINError, outputFile)
+	} else {
+		if isCheckedIN {
+			msg := fmt.Sprintf("ChangeRequest::%s is CheckedIn", changeRequestID)
+			response, outputError = cliProvider.generateCRActionResultMessage(changeRequestID, msg, outputFile)
+		} else {
+			response, outputError = cliProvider.generateErrorMessage(errors.New("Unable CheckIN the Change Request"), outputFile)
+		}
+	}
+	return response, checkINError, outputError
+}
+func (cliProvider MockupCMCLIProvider) ReviewChangeRequest(changeRequestID, comments, outputFile string) (string, error, error) {
+	var response string
+	var outputError error
+	isReviewed, reivewError := cliProvider.cmITFCMGR.ReviewChangeRequest(changeRequestID, comments)
+	log.Println("isCheckedIN is ", isReviewed)
+	log.Println("reivewError::", reivewError)
+	if reivewError != nil {
+		response, outputError = cliProvider.generateErrorMessage(reivewError, outputFile)
+	} else {
+		if isReviewed {
+			msg := fmt.Sprintf("ChangeRequest::%s is Reviewed", changeRequestID)
+			response, outputError = cliProvider.generateCRActionResultMessage(changeRequestID, msg, outputFile)
+		} else {
+			response, outputError = cliProvider.generateErrorMessage(errors.New("Unable move the Change Request to Review state"), outputFile)
+		}
+	}
+	return response, reivewError, outputError
+}
+
+func (cliProvider MockupCMCLIProvider) SignOffChangeRequest(changeRequestID, comments, outputFile string) (string, error, error) {
+	var response string
+	var outputError error
+	isSignedOff, signedOffErr := cliProvider.cmITFCMGR.SignOffChangeRequest(changeRequestID, comments)
+	log.Println("isSignedOff is ", isSignedOff)
+	log.Println("signedOffErr::", signedOffErr)
+	if signedOffErr != nil {
+		response, outputError = cliProvider.generateErrorMessage(signedOffErr, outputFile)
+	} else {
+		if isSignedOff {
+			msg := fmt.Sprintf("ChangeRequest::%s is SignedOff", changeRequestID)
+			response, outputError = cliProvider.generateCRActionResultMessage(changeRequestID, msg, outputFile)
+		} else {
+			response, outputError = cliProvider.generateErrorMessage(errors.New("Unable SignOff the Change Request"), outputFile)
+		}
+	}
+	return response, signedOffErr, outputError
+}
+func (cliProvider MockupCMCLIProvider) Validate(outputFile string) (string, error, error) {
+	var response string
+	var outputError error
+
+	log.Println("cliProvider.isValid::", cliProvider.isValid)
+
+	if cliProvider.isValid {
+		msg := fmt.Sprintf("CLI Validation is fine")
+		changeRequestID := ""
+		response, outputError = cliProvider.generateCRActionResultMessage(changeRequestID, msg, outputFile)
+	} else {
+		response, outputError = cliProvider.generateErrorMessage(errors.New("Unable Validate CLI"), outputFile)
+	}
+
+	return response, nil, outputError
+}
+
+func (cliMGR MockupCMCLIProvider) generateCRActionResultMessage(changeRequestID, message, outputFile string) (string, error) {
+	crActionResult := cm_models.CRActionResultType{
+		ChangeRequestID: changeRequestID,
+		Message:         message,
+	}
+
+	crActionResultPayLoad := cm_models.CMResponsePayLoad{
+		CRActionResult: crActionResult,
+		Status:         cm_models.STATUS_SUCCESS,
+	}
+	return writeAndReturnJson(outputFile, crActionResultPayLoad)
+}
+
+func (cliMGR MockupCMCLIProvider) generateErrorMessage(err error, outputFile string) (string, error) {
+	message := fmt.Sprintf("%v", err)
+	errorType := cm_models.ErrorType{
+		Message: message,
+	}
+	errorPaypLoad := cm_models.CMResponsePayLoad{
+		Error:  errorType,
+		Status: cm_models.STATUS_FAILURE,
+	}
+	return writeAndReturnJson(outputFile, errorPaypLoad)
+
+}
+
+func (cliMGR MockupCMCLIProvider) generateCRResultMessage(changeRequestID, crDetails, outputFile string) (string, error) {
+
+	crResult := cm_models.CRResultType{
+		ChangeRequestID: changeRequestID,
+		CRDetails:       crDetails,
+	}
+	crResultPaypLoad := cm_models.CMResponsePayLoad{
+		CRResult: crResult,
+		Status:   cm_models.STATUS_SUCCESS,
+	}
+	return writeAndReturnJson(outputFile, crResultPaypLoad)
+
+}
+
+func writeAndReturnYaml(outputFile string, payLoad interface{}) (string, error) {
+	result, err1 := yaml.Marshal(payLoad)
+	if err1 != nil {
+		return string(result), err1
+	} else {
+		writeFile(outputFile, result)
+		// ***IMP*** THIS FMT.PRINTLN IS REQUIRED TO  TO READ THE OUTPUT FROM CLI CLIENT
+		fmt.Println(string(result))
+		return string(result), nil
+	}
+}
+func writeAndReturnJson(outputFile string, payLoad interface{}) (string, error) {
+	result, err1 := json.MarshalIndent(payLoad, "", "")
+	if err1 != nil {
+		return string(result), err1
+	} else {
+		writeFile(outputFile, result)
+		// ***IMP*** THIS FMT.PRINTLN IS REQUIRED TO  TO READ THE OUTPUT FROM CLI CLIENT
+		fmt.Println(string(result))
+		return string(result), nil
+	}
+
+}
+func writeFile(outputFile string, data []byte) error {
+	if outputFile == "" {
+		return nil
+	}
+	err := os.WriteFile(outputFile, data, 0644)
+	return err
+}

--- a/mockups/change_management_system/provider/manager/mockup_cm_itfc_manager.go
+++ b/mockups/change_management_system/provider/manager/mockup_cm_itfc_manager.go
@@ -1,0 +1,237 @@
+package mockup_itfc_manager
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	cm_interfaces "github.com/braintree/heckler/change_management/interfaces"
+	mockup_cms_client "github.com/braintree/heckler/mockups/change_management_system/client"
+	"log"
+	"time"
+)
+
+const SN_TIME_LAYOUT = "2006-01-02 15:04:05"
+const DESC_PRE_FIX = "mockup change request for "
+
+/*
+MockupCMITFCManager is implementation class for cm_interfaces.ChangeManagementInterface which exposes minimum set of APIS to manage Changes
+This class is dependeing upon your change manage system either SNOW/JIRA/Internal CMS system ..need to interact with agent of that system.
+We had mockup_cms_client to imitate  like ServiceNow/JIRA client
+*/
+type MockupCMITFCManager struct {
+	cmsClient mockup_cms_client.MockupCMSClient
+	isValid   bool
+}
+
+func _newMockupCMITFCManager(cmsClient mockup_cms_client.MockupCMSClient) cm_interfaces.ChangeManagementInterface {
+	var cmITFCMGR cm_interfaces.ChangeManagementInterface = MockupCMITFCManager{cmsClient: cmsClient,
+		isValid: true}
+
+	return cmITFCMGR
+}
+
+func GetMockupCMITFCManager(cmCFGPath string) (MockupCMITFCManager, error) {
+	var emptyWrapper MockupCMITFCManager
+
+	cmsClient, err1 := mockup_cms_client.GetMockupCMSClient()
+	if err1 == nil {
+		cmITFCMGR := MockupCMITFCManager{cmsClient: cmsClient, isValid: true}
+		return cmITFCMGR, nil
+	} else {
+		return emptyWrapper, err1
+	}
+}
+func (cmITFCMGR MockupCMITFCManager) SearchChangeRequest(hecklerEnv, tag string) (string, error) {
+
+	isActive := "true"
+
+	description := GetDescriptions(DESC_PRE_FIX, hecklerEnv, tag)
+	log.Printf("SearchChangeRequestDetails hecklerEnv::%s isActive::%s description::%s tag::%s \n", hecklerEnv, isActive, description, tag)
+	changes, searchError := cmITFCMGR.cmsClient.SearchChangeRequestDetails(hecklerEnv, isActive, description, tag)
+	if searchError != nil {
+		log.Println("SearchChangeRequestDetails returns searchError", searchError)
+		return "", searchError
+	} else if len(changes) > 0 {
+		log.Println("change Requests", changes)
+		// IMP:: Changes are sorted by ORDERBYDESCsys_created_on so first record is latest changeRequest
+
+		crNumber := changes[0]["Number"]
+		if crNumber == nil {
+			return "", errors.New("CR Number is empty")
+		} else {
+			return fmt.Sprintf("%v", crNumber), nil
+		}
+	}
+	log.Printf("No of changes is Zero(%d) hence Returning empty changeRequestID and nil as error\n", len(changes))
+	return "", nil
+
+}
+func (cmITFCMGR MockupCMITFCManager) SearchAndCreateChangeRequest(hecklerEnv, tag string) (string, error) {
+	changeRequestID, err1 := cmITFCMGR.SearchChangeRequest(hecklerEnv, tag)
+	if err1 != nil {
+		return "", err1
+	} else if changeRequestID != "" {
+		return changeRequestID, nil
+	} else {
+		return cmITFCMGR.CreateChangeRequest(hecklerEnv, tag)
+	}
+
+}
+func (cmITFCMGR MockupCMITFCManager) CreateChangeRequest(hecklerEnv, tag string) (string, error) {
+	createTicketData := make(map[string]interface{})
+	createTicketData["env"] = hecklerEnv
+	createTicketData["tag"] = tag
+
+	isTicketCreated, changeRequestID, createError := cmITFCMGR.cmsClient.CreateChangeRequest(createTicketData)
+	log.Println("CreateChangeRequest returned", isTicketCreated, changeRequestID, createError)
+	return changeRequestID, createError
+
+}
+
+func (cmITFCMGR MockupCMITFCManager) CommentChangeRequest(changeRequestID, comments string) (bool, error) {
+	if changeRequestID == "" {
+		log.Println("changeRequestID is empty, so CommentChangeRequest return false ")
+		return false, nil
+	}
+
+	return cmITFCMGR._updateChangeRequest(changeRequestID, comments)
+}
+
+func (cmITFCMGR MockupCMITFCManager) CheckInChangeRequest(changeRequestID, comments string) (bool, error) {
+	if changeRequestID == "" {
+		log.Println("changeRequestID is empty, so CommentChangeRequest return false ")
+		return false, nil
+	}
+	if comments == "" {
+		comments = "moving/checking Change Request to Scheduled state"
+	}
+	isTicketScheduled, scheduleError := cmITFCMGR._scheduleChangeRequest(changeRequestID, comments)
+
+	if scheduleError == nil {
+		log.Print("isTicketScheduled is  ", isTicketScheduled, " and sleeping 60 seconds before moving CR to Implement state\n")
+		time.Sleep(time.Minute * 1)
+		reviewComments := "moving change Request to Implement state"
+		isTicketMovedToImplement, implementError := cmITFCMGR._moveChangeRequestToImplement(changeRequestID, reviewComments)
+
+		if implementError == nil {
+			log.Print("isTicketMovedToImplement is  ", isTicketMovedToImplement, "\n")
+
+			msg := "As there are no changeTask lets move the ChangeRequest to review state Directly"
+			log.Println(msg)
+			isChangeRequestReviewed, changeRequestReviewError := cmITFCMGR._moveChangeRequestToReview(changeRequestID, msg)
+			if changeRequestReviewError == nil {
+				log.Println("Successfully Moved changeRequest To Reviewed", isChangeRequestReviewed, changeRequestReviewError)
+			} else {
+				msg := fmt.Sprintf("Unable to invoke _MoveChangeRequestToReview::%v\n", changeRequestReviewError)
+				log.Println(msg)
+				return false, errors.New(msg)
+			}
+
+		} else {
+			log.Printf("Unable to invoke _moveChangeRequestToImplement::%v\n", implementError)
+			return false, implementError
+		}
+
+	} else {
+		log.Printf("Unable to invoke _scheduleChangeRequest::%v\n", scheduleError)
+		return false, scheduleError
+	}
+	return true, nil
+}
+
+func (cmITFCMGR MockupCMITFCManager) ReviewChangeRequest(changeRequestID, reviewComments string) (bool, error) {
+	if changeRequestID == "" {
+		log.Println("changeRequestID is empty, so CommentChangeRequest return false ")
+		return false, nil
+	}
+	if reviewComments == "" {
+		reviewComments = "moving change Request to Review state"
+	}
+	isReviewed, reviewError := cmITFCMGR._moveChangeRequestToReview(changeRequestID, reviewComments)
+	return isReviewed, reviewError
+}
+
+func (cmITFCMGR MockupCMITFCManager) SignOffChangeRequest(changeRequestID, comments string) (bool, error) {
+	if changeRequestID == "" {
+		log.Println("changeRequestID is empty, so CommentChangeRequest return false ")
+		return false, nil
+	}
+	if comments == "" {
+		comments = "moving change Request to Close state by Heckler"
+	}
+	closeCode := "Successful"
+	closeNotes := "Closed Ticket by Heckler"
+	state := "Closed"
+
+	isSignedOff, err2 := cmITFCMGR.cmsClient.SignOffChangeRequest(changeRequestID, comments, closeNotes, closeCode, state)
+	return isSignedOff, err2
+
+}
+
+func (cmITFCMGR MockupCMITFCManager) GetChangeRequestDetails(changeRequestID string) (string, error) {
+	if changeRequestID == "" {
+		log.Println("changeRequestID is empty, so CommentChangeRequest return false ")
+		return "", nil
+	}
+	changeRequestData, err2 := cmITFCMGR.cmsClient.GetChangeRequestDetails(changeRequestID)
+
+	if err2 != nil {
+		log.Println("err2::", err2)
+		return "", err2
+	} else {
+		log.Println("changeRequestData is ", changeRequestData)
+		crDetailsStr, marshalError := json.Marshal(changeRequestData)
+		if marshalError != nil {
+			log.Printf("error while Marshalling %v", marshalError)
+			return "", marshalError
+		}
+		return string(crDetailsStr), nil
+	}
+
+}
+
+func (cmITFCMGR MockupCMITFCManager) Validate() (bool, error) {
+	return cmITFCMGR.isValid, nil
+}
+
+func (cmITFCMGR MockupCMITFCManager) _moveChangeRequestToImplement(changeRequestID, comments string) (bool, error) {
+	if comments == "" {
+		comments = "moving change Request to Implement state"
+	}
+	state := "Implement"
+	return cmITFCMGR._checkInChangeRequest(changeRequestID, comments, state)
+}
+func (cmITFCMGR MockupCMITFCManager) _scheduleChangeRequest(changeRequestID, comments string) (bool, error) {
+	state := "Scheduled"
+	return cmITFCMGR._checkInChangeRequest(changeRequestID, comments, state)
+
+}
+
+func (cmITFCMGR MockupCMITFCManager) _moveChangeRequestToReview(changeRequestID, comments string) (bool, error) {
+
+	return cmITFCMGR.cmsClient.ReviewChangeRequest(changeRequestID, comments)
+
+}
+func (cmITFCMGR MockupCMITFCManager) _updateChangeRequest(changeRequestID, comments string) (bool, error) {
+	isUpdated, err2 := cmITFCMGR.cmsClient.UpdateChangeRequest(changeRequestID, comments)
+	return isUpdated, err2
+
+}
+
+func (cmITFCMGR MockupCMITFCManager) _checkInChangeRequest(changeRequestID, comments, state string) (bool, error) {
+	isCheckedIn, err2 := cmITFCMGR.cmsClient.CheckInChangeRequest(changeRequestID, comments, state)
+	return isCheckedIn, err2
+
+}
+
+func (cmITFCMGR MockupCMITFCManager) _signOffChangeTask(parentID, taskNo, workNotes string) (bool, error) {
+
+	state := "Closed Complete"
+	isUpdated, err2 := cmITFCMGR.cmsClient.SignoffChangeTask(parentID, taskNo, workNotes, state)
+	return isUpdated, err2
+
+}
+
+func GetDescriptions(description_prefix, hecklerEnv, tag string) string {
+	return fmt.Sprintf("%s %s::%s", description_prefix, hecklerEnv, tag)
+}

--- a/mockups/utils/response/response_util.go
+++ b/mockups/utils/response/response_util.go
@@ -1,0 +1,41 @@
+package response_util
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	cm_models "github.com/braintree/heckler/change_management/models"
+	"os"
+)
+
+/*
+writes Json string to a file
+*/
+func GetResponseJsonFromFile(outputFile string, outb bytes.Buffer) (cm_models.CMResponsePayLoad, error) {
+	var responseJson string
+	var emptyCMResponse cm_models.CMResponsePayLoad
+	cmResponse := new(cm_models.CMResponsePayLoad)
+	if outputFile == "" {
+		responseJson = outb.String()
+	} else {
+		outputBytes, readError := os.ReadFile(outputFile)
+		if readError == nil {
+			responseJson = string(outputBytes)
+		} else {
+			return emptyCMResponse, readError
+		}
+	}
+
+	err := json.Unmarshal([]byte(responseJson), cmResponse)
+	return *cmResponse, err
+}
+
+func GetResponseJson(outputJson string) (cm_models.CMResponsePayLoad, error) {
+	var emptyCMResponse cm_models.CMResponsePayLoad
+	cmResponse := new(cm_models.CMResponsePayLoad)
+	if outputJson == "" {
+		return emptyCMResponse, errors.New("output is Empty")
+	}
+	err := json.Unmarshal([]byte(outputJson), cmResponse)
+	return *cmResponse, err
+}

--- a/tests/cm/adapter/cli/validate_cm_adpater_with_cli_test.go
+++ b/tests/cm/adapter/cli/validate_cm_adpater_with_cli_test.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"fmt"
+	cm_adapter "github.com/braintree/heckler/change_management/adapter"
+	"log"
+	"testing"
+)
+
+/*
+This test validates cm_adapter.ChangeManagementAdapter (change_management/adapter/cm_adapter.go[cm_adapter.NewCMAdapter]) CLI application built using mockups/change_manage_system/cmd/mockup-cm-cli/main.go
+cm_adapter.NewCMAdapter(cmAdapterConfig, nil)[interfaceManager is passed as nil]
+cmAdapterConfig has a config with valid CLI CMD PATH[cmAdapterConfig["cli_agent_path"] = CLI_CMD_PATH]
+
+
+cmAgent inside CMADapter is CLI binary application.
+*/
+const CLI_CMD_PATH = "../../../../mockup-cm-cli"
+const TEST_DESC_PREFIX = "Heckler Testing for Tag::"
+const TAG_VALUE = "v99"
+const ENV_PREFIX = "MOCKTESTING"
+
+var cmAdapter cm_adapter.ChangeManagementAdapter
+var cmAdapterError error
+
+func init() {
+
+	log.SetFlags(log.LstdFlags | log.Lshortfile)
+	cmAdapterConfig := make(map[string]interface{})
+	cmAdapterConfig["plugin_agent_path"] = ""
+	cmAdapterConfig["cli_agent_path"] = CLI_CMD_PATH
+	cmAdapterConfig["cm_config_path"] = "/etc/hecklerd/cm_config_conf.yaml"
+	cmAdapterConfig["is_mandatory"] = true
+	cmAdapterConfig["on_error_stop"] = true
+	cmAdapterConfig["verbose"] = true
+	log.Println("cmAdapterConfig...", cmAdapterConfig)
+	cmAdapter, cmAdapterError = cm_adapter.NewCMAdapter(cmAdapterConfig, nil)
+}
+func getEnvPrefixFlag() string { return "-env_prefix=" + ENV_PREFIX }
+func getTagFlag() string       { return "-tag=" + TAG_VALUE }
+func getVerboseFlag(verbose bool) string {
+	if verbose {
+		return "-verbose=true"
+	} else {
+		return ""
+	}
+}
+func getCommandFlag(command string) string       { return "-command=" + command }
+func getOutputFileFlag(outputFile string) string { return "-output_file=" + outputFile }
+func getChangeRequestIDFlag(changeRequestID string) string {
+	return "-change_request_id=" + changeRequestID
+}
+func TestAllAPIS(t *testing.T) {
+	fmt.Println("inside TestAllAPIS")
+	if cmAdapterError != nil {
+		t.Errorf(fmt.Sprintf("%v", cmAdapterError))
+		return
+	}
+	var changeRequestID string
+
+	log.Println("Going to invoke _createChangeRequest")
+	checkInComments := "checkin comments by CM adapter test cases"
+	changeRequestID, pauseExeuction := _CreateAndCheckInCR(t, checkInComments)
+	if pauseExeuction == true {
+		t.Errorf("got pauseExeuction as true from _CreateAndCheckInCR")
+		return
+	}
+	if changeRequestID != "" {
+
+		isCommented, commentError := _commentChangeRequest(t, changeRequestID)
+		log.Println("isCommented", isCommented)
+		if commentError != nil {
+			t.Errorf(fmt.Sprintf("%v", commentError))
+		}
+		isSignOff, signOffError := _signOffChangeRequest(t, changeRequestID)
+		log.Println("isSignOff", isSignOff)
+		if signOffError != nil {
+			t.Errorf(fmt.Sprintf("%v", signOffError))
+		}
+	}
+
+}
+func testCommentChangeRequest(t *testing.T, changeRequestID string) {
+	isCommented, commentError := _commentChangeRequest(t, changeRequestID)
+	log.Println("isCommented", isCommented)
+	if commentError != nil {
+		t.Errorf(fmt.Sprintf("%v", commentError))
+	}
+}
+
+func _CreateAndCheckInCR(t *testing.T, checkInComments string) (string, bool) {
+	fmt.Println("inside _CreateAndCheckInCR")
+	if cmAdapterError != nil {
+		t.Errorf(fmt.Sprintf("%v", cmAdapterError))
+		return "", true
+	}
+	return cmAdapter.CreateAndCheckInCR(ENV_PREFIX, TAG_VALUE, checkInComments)
+}
+
+func _commentChangeRequest(t *testing.T, changeRequestID string) (bool, error) {
+	fmt.Println("inside _commentChangeRequest")
+	comments := "comments by cm adatper-cli"
+	if cmAdapterError != nil {
+		t.Errorf(fmt.Sprintf("%v", cmAdapterError))
+		return false, cmAdapterError
+	}
+	return cmAdapter.CommentChangeRequest(changeRequestID, comments)
+}
+func _signOffChangeRequest(t *testing.T, changeRequestID string) (bool, error) {
+	fmt.Println("inside _signOffChangeRequest")
+	comments := "_signOffChangeRequest by cm adatper-cli"
+	if cmAdapterError != nil {
+		t.Errorf(fmt.Sprintf("%v", cmAdapterError))
+		return false, cmAdapterError
+	}
+	return cmAdapter.SignOffChangeRequest(changeRequestID, comments)
+}

--- a/tests/cm/adapter/manager/validate_cm_adpater_with_itfc_manager_test.go
+++ b/tests/cm/adapter/manager/validate_cm_adpater_with_itfc_manager_test.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"fmt"
+	cm_adapter "github.com/braintree/heckler/change_management/adapter"
+	itfc_mockup "github.com/braintree/heckler/mockups/change_management_system/provider/manager"
+
+	"log"
+	"testing"
+)
+
+const TEST_DESC_PREFIX = "Heckler Testing for Tag::"
+const TAG_VALUE = "v99"
+const ENV_PREFIX = "MOCKTESTING"
+
+var cmAdapter cm_adapter.ChangeManagementAdapter
+var cmAdapterError error
+
+/*
+This test validates cm_adapter.ChangeManagementAdapter (change_management/adapter/cm_adapter.go[cm_adapter.NewCMAdapter]) CLI application built using mockups/change_manage_system/cmd/mockup-cm-cli/main.go
+cm_adapter.NewCMAdapter(cmAdapterConfig, itfcMgr)[a provider interfaceManager is passed]
+cmAdapterConfig have a config with empty CLI CMD PATH path [cmAdapterConfig["cli_agent_path"] = "]
+cmAgent inside CMADapter is interfaceManager, directlys call it as another structs functions.
+*/
+func init() {
+
+	log.SetFlags(log.LstdFlags | log.Lshortfile)
+	cmAdapterConfig := make(map[string]interface{})
+	cmAdapterConfig["plugin_agent_path"] = ""
+	cmAdapterConfig["cli_agent_path"] = ""
+	cmAdapterConfig["cm_config_path"] = "/etc/hecklerd/cm_config_conf.yaml"
+	cmAdapterConfig["is_mandatory"] = true
+	cmAdapterConfig["on_error_stop"] = true
+	cmAdapterConfig["verbose"] = true
+	itfcMgr, itfcError := itfc_mockup.GetMockupCMITFCManager("/etc/hecklerd/cm_config_conf.yaml")
+	if itfcError == nil {
+		cmAdapter, cmAdapterError = cm_adapter.NewCMAdapter(cmAdapterConfig, itfcMgr)
+		if cmAdapterError != nil {
+			fmt.Println("cmAdapterError", cmAdapterError)
+			log.Fatalf("cmAdapterError %v", cmAdapterError)
+		}
+	} else {
+		cmAdapterError = itfcError
+	}
+}
+func getEnvPrefixFlag() string { return "-env_prefix=" + ENV_PREFIX }
+func getTagFlag() string       { return "-tag=" + TAG_VALUE }
+func getVerboseFlag(verbose bool) string {
+	if verbose {
+		return "-verbose=true"
+	} else {
+		return ""
+	}
+}
+func getCommandFlag(command string) string       { return "-command=" + command }
+func getOutputFileFlag(outputFile string) string { return "-output_file=" + outputFile }
+func getChangeRequestIDFlag(changeRequestID string) string {
+	return "-change_request_id=" + changeRequestID
+}
+func TestAllAPIS(t *testing.T) {
+	fmt.Println("inside TestAllAPIS")
+	if cmAdapterError != nil {
+		t.Errorf(fmt.Sprintf("%v", cmAdapterError))
+		return
+	}
+	var changeRequestID string
+
+	log.Println("Going to invoke _createChangeRequest")
+	checkInComments := "checkin comments by CM adapter test cases"
+	changeRequestID, pauseExeuction := _CreateAndCheckInCR(t, checkInComments)
+	if pauseExeuction == true {
+		t.Errorf("got pauseExeuction as true from _CreateAndCheckInCR")
+		return
+	}
+	log.Println("changeRequestID...", changeRequestID)
+	if changeRequestID != "" {
+
+		isCommented, commentError := _commentChangeRequest(t, changeRequestID)
+		log.Println("isCommented", isCommented)
+		if commentError != nil {
+			t.Errorf(fmt.Sprintf("%v", commentError))
+		}
+		isSignOff, signOffError := _signOffChangeRequest(t, changeRequestID)
+		log.Println("isSignOff", isSignOff)
+		if signOffError != nil {
+			t.Errorf(fmt.Sprintf("%v", signOffError))
+		}
+	}
+
+}
+func testCommentChangeRequest(t *testing.T, changeRequestID string) {
+	isCommented, commentError := _commentChangeRequest(t, changeRequestID)
+	log.Println("isCommented", isCommented)
+	if commentError != nil {
+		t.Errorf(fmt.Sprintf("%v", commentError))
+	}
+}
+
+func _CreateAndCheckInCR(t *testing.T, checkInComments string) (string, bool) {
+	fmt.Println("inside _CreateAndCheckInCR")
+	if cmAdapterError != nil {
+		t.Errorf(fmt.Sprintf("%v", cmAdapterError))
+		return "", true
+	}
+	return cmAdapter.CreateAndCheckInCR(ENV_PREFIX, TAG_VALUE, checkInComments)
+}
+
+func _commentChangeRequest(t *testing.T, changeRequestID string) (bool, error) {
+	fmt.Println("inside _commentChangeRequest")
+	comments := "comments by cm adatper-cli"
+	if cmAdapterError != nil {
+		t.Errorf(fmt.Sprintf("%v", cmAdapterError))
+		return false, cmAdapterError
+	}
+	return cmAdapter.CommentChangeRequest(changeRequestID, comments)
+}
+func _signOffChangeRequest(t *testing.T, changeRequestID string) (bool, error) {
+	fmt.Println("inside _signOffChangeRequest")
+	comments := "_signOffChangeRequest by cm adatper-cli"
+	if cmAdapterError != nil {
+		t.Errorf(fmt.Sprintf("%v", cmAdapterError))
+		return false, cmAdapterError
+	}
+	return cmAdapter.SignOffChangeRequest(changeRequestID, comments)
+}

--- a/tests/cm/cmd/validate_cli_cmd_test.go
+++ b/tests/cm/cmd/validate_cli_cmd_test.go
@@ -1,0 +1,282 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	cm_models "github.com/braintree/heckler/change_management/models"
+	response_util "github.com/braintree/heckler/mockups/utils/response"
+	"io/ioutil"
+	"log"
+	"os"
+	"os/exec"
+	"testing"
+)
+
+/*
+This test validates mockup-cm-cli binary CLI application built using mockups/change_manage_system/cmd/mockup-cm-cli/main.go
+It uses cmd := exec.Command() and cmd.Run() to invoke this binary CLI application
+*/
+
+const CLI_CMD_PATH = "../../../mockup-cm-cli"
+const TEST_DESC_PREFIX = "Heckler Testing for Tag::"
+const TAG_VALUE = "v99"
+const ENV_PREFIX = "MOCKTESTING"
+
+func init() {
+
+	log.SetFlags(log.LstdFlags | log.Lshortfile)
+}
+func getEnvPrefixFlag() string { return "-env_prefix=" + ENV_PREFIX }
+func getTagFlag() string       { return "-tag=" + TAG_VALUE }
+func getVerboseFlag(verbose bool) string {
+	if verbose {
+		return "-verbose=true"
+	} else {
+		return ""
+	}
+}
+func getCommandFlag(command string) string       { return "-command=" + command }
+func getCommentsFlag(command string) string      { return "-comments=" + command }
+func getOutputFileFlag(outputFile string) string { return "-output_file=" + outputFile }
+func getChangeRequestIDFlag(changeRequestID string) string {
+	return "-change_request_id=" + changeRequestID
+}
+
+func getExitCodeOrPathError(err error) int {
+	var exitError *exec.ExitError
+	var pathError *os.PathError
+	if errors.As(err, &exitError) {
+		if exitError.ExitCode() == 1 {
+			return 1
+		} else if exitError.ExitCode() == 2 {
+			return 2
+		} else {
+			return exitError.ExitCode()
+		}
+	} else if errors.As(err, &pathError) {
+		log.Println("pathError ,return ExitCode as -1", pathError)
+		return -1
+	} else if err != nil {
+		log.Println("Unknown Error, Not able to determine ExitCode,return ExitCode as -2")
+		return -2
+	} else {
+		return 0
+	}
+}
+
+func verifyCLIPath(t *testing.T) error {
+	log.Println("inside verifyCLIPath")
+	_, err := exec.LookPath(CLI_CMD_PATH)
+	if err != nil {
+		t.Errorf(fmt.Sprintf("%t", err))
+	}
+	return err
+
+}
+func _getTempFile(t *testing.T) (*os.File, error) {
+
+	jsonFile, fileError := ioutil.TempFile("/tmp", "validate_cli_cm_test_output"+".*.json")
+	if fileError != nil {
+		t.Errorf(fmt.Sprintf("%s", fileError))
+	}
+	return jsonFile, fileError
+}
+
+func testCreateCR(t *testing.T) {
+	fmt.Println("inside TestCreateCR")
+	if verifyCLIPath(t) != nil {
+		return
+	}
+	var outputFile string
+	jsonFile, fileError := _getTempFile(t)
+	if fileError != nil {
+		return
+	}
+	defer os.Remove(jsonFile.Name())
+	outputFile = jsonFile.Name()
+
+	cmd := exec.Command(CLI_CMD_PATH, getCommandFlag("CreateChangeRequest"), getEnvPrefixFlag(), getTagFlag(), getOutputFileFlag(outputFile), getVerboseFlag(true))
+	// 	stdout, err := cmd.Output()
+	var outb, errb bytes.Buffer
+	cmd.Stdout = &outb
+	cmd.Stderr = &errb
+	err := cmd.Run()
+	log.Println("output", outb.String())
+	log.Println("Stderr...", cmd.Stderr)
+	responseJson, responseError := response_util.GetResponseJsonFromFile(outputFile, outb)
+	log.Println(responseJson, responseError)
+	exitCode := getExitCodeOrPathError(err)
+	log.Println("ExitCode::", exitCode)
+	_checkExitCode(t, exitCode)
+
+	_checkResponseJson(t, responseJson)
+
+}
+func _checkResponseJson(t *testing.T, responseJson cm_models.CMResponsePayLoad) {
+	if responseJson.Status == cm_models.STATUS_FAILURE {
+		log.Println("responseJson.Error...", responseJson.Error.Message, responseJson.Error.Detail)
+		t.Errorf(responseJson.Error.Message)
+		t.Errorf(responseJson.Error.Detail)
+	}
+}
+func _checkExitCode(t *testing.T, exitCode int) {
+	if exitCode == 0 {
+		log.Println("exit code is zero,Call is success")
+	} else if exitCode == 1 {
+		t.Errorf("empty Response ERROR Code::%d", exitCode)
+	} else if exitCode == 3 {
+		t.Errorf("output generation ERROR Code::%d", exitCode)
+	} else if exitCode == 2 {
+		t.Errorf("CM ERROR Code::%d", exitCode)
+	} else if exitCode == -1 || exitCode == -2 {
+		t.Errorf("Unknown Exist Code::%d", exitCode)
+	}
+}
+func TestAllmethods(t *testing.T) {
+	if verifyCLIPath(t) != nil {
+		return
+	}
+	changeRequestID, err := invokeCreateChangeRequest(t)
+	if err != nil {
+		t.Errorf(fmt.Sprintf("%t", err))
+		return
+	} else if changeRequestID == "" {
+		t.Errorf("changeRequestID is none from invokeCheckInChangeRequest")
+		return
+	}
+	log.Println("..invokeCommentChangeRequest with", changeRequestID)
+	invokeCommentChangeRequest(t, changeRequestID)
+
+	invokeCheckInChangeRequest(t, changeRequestID)
+	invokeSignOffChangeRequest(t, changeRequestID)
+
+}
+
+func invokeCommand(t *testing.T, outputFileName string, arguments ...string) (cm_models.CMResponsePayLoad, error) {
+	log.Println("inside invokeCommand")
+	var outb, errb bytes.Buffer
+	var emptyResponse cm_models.CMResponsePayLoad
+	arguments = append(arguments, getOutputFileFlag(outputFileName))
+	arguments = append(arguments, getVerboseFlag(true))
+
+	cmd := exec.Command(CLI_CMD_PATH, arguments...)
+	cmd.Stdout = &outb
+	cmd.Stderr = &errb
+	cmdErr := cmd.Run()
+	log.Println("output", outb.String())
+	log.Println("Stderr...", cmd.Stderr)
+	if cmdErr != nil {
+		t.Errorf(fmt.Sprintf("%t", cmdErr))
+
+	}
+	exitCode := getExitCodeOrPathError(cmdErr)
+	log.Println("ExitCode::", exitCode)
+	_checkExitCode(t, exitCode)
+	if exitCode != 0 {
+		return emptyResponse, cmdErr
+	} else {
+		responseJson, responseErr := response_util.GetResponseJsonFromFile(outputFileName, outb)
+		log.Println(responseJson, responseErr)
+
+		_checkResponseJson(t, responseJson)
+		return responseJson, responseErr
+	}
+
+}
+func invokeCreateChangeRequest(t *testing.T) (string, error) {
+	var arguments []string
+	arguments = append(arguments, getCommandFlag("CreateChangeRequest"))
+	arguments = append(arguments, getEnvPrefixFlag())
+	arguments = append(arguments, getTagFlag())
+	jsonFile, fileError := _getTempFile(t)
+	if fileError != nil {
+		return "", fileError
+	}
+	defer os.Remove(jsonFile.Name())
+	outputFileName := jsonFile.Name()
+
+	responseJson, responseError := invokeCommand(t, outputFileName, arguments...)
+	if responseError != nil {
+		return "", responseError
+	} else {
+		if responseJson.Status == cm_models.STATUS_FAILURE {
+			return "", errors.New("Create CR is failed")
+		} else {
+			return responseJson.CRResult.ChangeRequestID, nil
+		}
+
+	}
+}
+
+func invokeCommentChangeRequest(t *testing.T, changeRequestID string) (string, error) {
+	log.Println("inside invokeCommentChangeRequest", changeRequestID)
+
+	var arguments []string
+	arguments = append(arguments, getCommandFlag("CommentChangeRequest"))
+	arguments = append(arguments, getEnvPrefixFlag())
+	arguments = append(arguments, getTagFlag())
+	arguments = append(arguments, getChangeRequestIDFlag(changeRequestID))
+	arguments = append(arguments, getCommentsFlag("comments by invokeCommentChangeRequest by testing"))
+	jsonFile, fileError := _getTempFile(t)
+	if fileError != nil {
+		return "", fileError
+	}
+	defer os.Remove(jsonFile.Name())
+	outputFileName := jsonFile.Name()
+
+	responseJson, responseError := invokeCommand(t, outputFileName, arguments...)
+	if responseError != nil {
+		return "", responseError
+	} else {
+		return responseJson.CRActionResult.Message, nil
+	}
+}
+
+func invokeCheckInChangeRequest(t *testing.T, changeRequestID string) (string, error) {
+	log.Println("inside invokeCheckInChangeRequest", changeRequestID)
+
+	var arguments []string
+	arguments = append(arguments, getCommandFlag("CheckInChangeRequest"))
+	arguments = append(arguments, getEnvPrefixFlag())
+	arguments = append(arguments, getTagFlag())
+	arguments = append(arguments, getChangeRequestIDFlag(changeRequestID))
+	arguments = append(arguments, getCommentsFlag("comments by invokeCommentChangeRequest by testing"))
+	jsonFile, fileError := _getTempFile(t)
+	if fileError != nil {
+		return "", fileError
+	}
+	defer os.Remove(jsonFile.Name())
+	outputFileName := jsonFile.Name()
+
+	responseJson, responseError := invokeCommand(t, outputFileName, arguments...)
+	if responseError != nil {
+		return "", responseError
+	} else {
+		return responseJson.CRActionResult.Message, nil
+	}
+}
+
+func invokeSignOffChangeRequest(t *testing.T, changeRequestID string) (string, error) {
+	log.Println("inside invokeSignOffChangeRequest", changeRequestID)
+
+	var arguments []string
+	arguments = append(arguments, getCommandFlag("SignOffChangeRequest"))
+	arguments = append(arguments, getEnvPrefixFlag())
+	arguments = append(arguments, getTagFlag())
+	arguments = append(arguments, getChangeRequestIDFlag(changeRequestID))
+	arguments = append(arguments, getCommentsFlag("comments by invokeCommentChangeRequest by testing"))
+	jsonFile, fileError := _getTempFile(t)
+	if fileError != nil {
+		return "", fileError
+	}
+	defer os.Remove(jsonFile.Name())
+	outputFileName := jsonFile.Name()
+
+	responseJson, responseError := invokeCommand(t, outputFileName, arguments...)
+	if responseError != nil {
+		return "", responseError
+	} else {
+		return responseJson.CRActionResult.Message, nil
+	}
+}

--- a/tests/cm/provider/validate_cli_cmd_provider_test.go
+++ b/tests/cm/provider/validate_cli_cmd_provider_test.go
@@ -1,0 +1,262 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	cm_models "github.com/braintree/heckler/change_management/models"
+	cm_cli_provider "github.com/braintree/heckler/mockups/change_management_system/provider/cli"
+	response_util "github.com/braintree/heckler/mockups/utils/response"
+	"log"
+	"testing"
+)
+
+/*
+This test validates MockupCMCLIProvider (which  is actual logic calling CM Interface Manager)
+*/
+
+const TEST_DESC_PREFIX = "Heckler Testing for Tag::"
+const TAG_VALUE = "v99"
+const ENV_PREFIX = "MOCKTESTING"
+const EMPTY_OUTPUT_FILE_NAME = ""
+
+var CM_CONFI_PATH = "/etc/hecklerd/cm_config_conf.yaml"
+var mockupcmCLIProvider cm_cli_provider.MockupCMCLIProvider
+var providerError error
+
+func init() {
+	log.SetFlags(log.LstdFlags | log.Lshortfile)
+	mockupcmCLIProvider, providerError = cm_cli_provider.GetMockupCMCLIProvider(CM_CONFI_PATH)
+}
+
+func TestAllMethods(t *testing.T) {
+	fmt.Println("inside TestAllMethods")
+	if providerError != nil {
+		t.Errorf(fmt.Sprintf("%t", providerError))
+		return
+	}
+	isValid, validError := invokeValidate(t)
+	if validError != nil {
+		t.Errorf(fmt.Sprintf("%t", validError))
+		return
+	}
+	if isValid == false {
+		t.Errorf("Provider is not valid")
+		return
+	}
+	changeRequestID, createExeuction := invokeCreateChangeRequest(t)
+	if createExeuction != nil {
+		t.Errorf(fmt.Sprintf("%t", createExeuction))
+		return
+	}
+
+	if changeRequestID != "" {
+
+		isCommented, commentError := _invokeCommentChangeRequest(t, changeRequestID)
+		log.Println("isCommented", isCommented)
+		if commentError != nil {
+			t.Errorf(fmt.Sprintf("%v", commentError))
+		}
+		isCheckIn, checkInError := _checkInChangeRequest(t, changeRequestID)
+		log.Println("isCheckIn", isCheckIn)
+		if checkInError != nil {
+			t.Errorf(fmt.Sprintf("%v", checkInError))
+		}
+
+		isSignOff, signOffError := _signOffChangeRequest(t, changeRequestID)
+		log.Println("isSignOff", isSignOff)
+		if signOffError != nil {
+			t.Errorf(fmt.Sprintf("%v", signOffError))
+		}
+	}
+
+}
+
+func invokeSearchAndCreateCR(t *testing.T) {
+	log.Println("inside invokeSearchAndCreateCR")
+
+	mockupcmCLIProvider.SearchAndCreateChangeRequest(ENV_PREFIX, TAG_VALUE, EMPTY_OUTPUT_FILE_NAME)
+
+}
+
+func invokeSearchChangeRequest() (string, error) {
+	log.Println("inside invokeSearchChangeRequest")
+
+	mockupcmCLIProvider.SearchChangeRequest(ENV_PREFIX, TAG_VALUE, EMPTY_OUTPUT_FILE_NAME)
+	return "", nil
+}
+func invokeSearchAndCreateChangeRequest() (string, error) {
+	log.Println("inside invokeSearchAndCreateChangeRequest")
+
+	mockupcmCLIProvider.SearchAndCreateChangeRequest(ENV_PREFIX, TAG_VALUE, EMPTY_OUTPUT_FILE_NAME)
+	return "", nil
+}
+func invokeCreateChangeRequest(t *testing.T) (string, error) {
+	log.Println("inside invokeCreateChangeRequest")
+
+	response, createError, outputError := mockupcmCLIProvider.CreateChangeRequest(ENV_PREFIX, TAG_VALUE, EMPTY_OUTPUT_FILE_NAME)
+
+	if createError != nil {
+		t.Errorf(fmt.Sprintf("%t", createError))
+		return "", createError
+	}
+	if outputError != nil {
+		t.Errorf(fmt.Sprintf("%t", outputError))
+		return "", outputError
+	}
+	responseJson, responseError := response_util.GetResponseJson(response)
+	_checkResponseJson(t, responseJson)
+
+	if responseError != nil {
+		return "", responseError
+	} else {
+		if responseJson.Status == cm_models.STATUS_FAILURE {
+			return "", errors.New("Create CR is failed")
+		} else {
+			return responseJson.CRResult.ChangeRequestID, nil
+		}
+
+	}
+
+}
+func invokeGetChangeRequestDetails(t *testing.T, changeRequestID string) (string, error) {
+	log.Println("inside invokeGetChangeRequestDetails", changeRequestID)
+
+	response, createError, outputError := mockupcmCLIProvider.GetChangeRequestDetails(changeRequestID, EMPTY_OUTPUT_FILE_NAME)
+
+	if createError != nil {
+		t.Errorf(fmt.Sprintf("%t", createError))
+		return "", createError
+	}
+	if outputError != nil {
+		t.Errorf(fmt.Sprintf("%t", outputError))
+		return "", outputError
+	}
+	responseJson, responseError := response_util.GetResponseJson(response)
+	_checkResponseJson(t, responseJson)
+
+	if responseError != nil {
+		return "", responseError
+	} else {
+		if responseJson.Status == cm_models.STATUS_FAILURE {
+			return "", errors.New("Create CR is failed")
+		} else {
+			return responseJson.CRResult.ChangeRequestID, nil
+		}
+
+	}
+}
+
+func _invokeCommentChangeRequest(t *testing.T, changeRequestID string) (bool, error) {
+	log.Println("inside invokeCommentChangeRequest", changeRequestID)
+
+	response, createError, outputError := mockupcmCLIProvider.CommentChangeRequest(changeRequestID, "testing using cli", EMPTY_OUTPUT_FILE_NAME)
+
+	if createError != nil {
+		t.Errorf(fmt.Sprintf("%t", createError))
+		return false, createError
+	}
+	if outputError != nil {
+		t.Errorf(fmt.Sprintf("%t", outputError))
+		return false, outputError
+	}
+	responseJson, responseError := response_util.GetResponseJson(response)
+	_checkResponseJson(t, responseJson)
+
+	if responseError != nil {
+		return false, responseError
+	} else {
+		if responseJson.Status == cm_models.STATUS_FAILURE {
+			return false, errors.New("CR is not commented")
+		} else {
+			return true, nil
+		}
+
+	}
+}
+func _checkInChangeRequest(t *testing.T, changeRequestID string) (bool, error) {
+	response, createError, outputError := mockupcmCLIProvider.CheckInChangeRequest(changeRequestID, "checkin by testing -invokeCheckInChangeRequest", EMPTY_OUTPUT_FILE_NAME)
+
+	if createError != nil {
+		t.Errorf(fmt.Sprintf("%t", createError))
+		return false, createError
+	}
+	if outputError != nil {
+		t.Errorf(fmt.Sprintf("%t", outputError))
+		return false, outputError
+	}
+	responseJson, responseError := response_util.GetResponseJson(response)
+	_checkResponseJson(t, responseJson)
+
+	if responseError != nil {
+		return false, responseError
+	} else {
+		if responseJson.Status == cm_models.STATUS_FAILURE {
+			return false, errors.New("CR is not checkedin")
+		} else {
+			return true, nil
+		}
+
+	}
+}
+func _signOffChangeRequest(t *testing.T, changeRequestID string) (bool, error) {
+	log.Println("inside invokeSignOffChangeRequest", changeRequestID)
+
+	response, createError, outputError := mockupcmCLIProvider.SignOffChangeRequest(changeRequestID, "signoff by testing -invokeCheckInChangeRequest", EMPTY_OUTPUT_FILE_NAME)
+
+	if createError != nil {
+		t.Errorf(fmt.Sprintf("%t", createError))
+		return false, createError
+	}
+	if outputError != nil {
+		t.Errorf(fmt.Sprintf("%t", outputError))
+		return false, outputError
+	}
+	responseJson, responseError := response_util.GetResponseJson(response)
+	_checkResponseJson(t, responseJson)
+
+	if responseError != nil {
+		return false, responseError
+	} else {
+		if responseJson.Status == cm_models.STATUS_FAILURE {
+			return false, errors.New("CR is not signedoff")
+		} else {
+			return true, nil
+		}
+
+	}
+}
+func _checkResponseJson(t *testing.T, responseJson cm_models.CMResponsePayLoad) {
+	if responseJson.Status == cm_models.STATUS_FAILURE {
+		log.Println("responseJson.Error...", responseJson.Error.Message, responseJson.Error.Detail)
+		t.Errorf(responseJson.Error.Message)
+		t.Errorf(responseJson.Error.Detail)
+	}
+}
+
+func invokeValidate(t *testing.T) (bool, error) {
+	response, respError, outputError := mockupcmCLIProvider.Validate(EMPTY_OUTPUT_FILE_NAME)
+	if respError != nil {
+		t.Errorf(fmt.Sprintf("%t", respError))
+		return false, respError
+	}
+	if outputError != nil {
+		t.Errorf(fmt.Sprintf("%t", outputError))
+		return false, outputError
+	}
+	responseJson, responseError := response_util.GetResponseJson(response)
+	_checkResponseJson(t, responseJson)
+	if responseError != nil {
+		t.Errorf(fmt.Sprintf("%t", responseError))
+		return false, responseError
+	} else {
+		if responseJson.Status == cm_models.STATUS_FAILURE {
+			log.Println("responseJson.Error.Message..", responseJson.Error.Message)
+			log.Println("responseJson.Error.Detail..", responseJson.Error.Detail)
+			t.Errorf("mockupcmCLIProvider is not valid")
+			return false, errors.New(responseJson.Error.Message)
+		} else {
+			return true, nil
+		}
+
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -179,3 +179,4 @@ google.golang.org/grpc/tap
 gopkg.in/yaml.v3
 # vbom.ml/util v0.0.0-20150502001426-d600ec780753
 vbom.ml/util/sortorder
+# github.com/braintree/heckler => ../heckler


### PR DESCRIPTION
This PR contains ChangeManagementAdapter concept.
Apart of using the "Github issues" to track deployment status of puppet applies on nodes. This new Adapter enables to use any change management systems like JIRA/SNOW/internal ticket systems with additional logic(that is specific to each company). It has a bunch of  simplified functions that are integrated with hecklerd/main.go. Based upon return values hecklerd either continue to apply puppet changes on nodes or skip them. 
[1. In case of not able to create a Change Request 2. In case  there is freeze on code/config changes in PROD env]

It has 2  important things 
1. CM Adapter and cm_agent_cli (part of this PR)
2. CM CLI provider (a CLI that will interact with JIRA/SNOW/interact ticket). Every company has their own logic of creating/ updating Change Requests and determining if there is code/config freeze or deployment holiday ... These type of logics will be part of CM CLI provider.CLI developer has to implement a set of functions that are exposed in CM Interface and provide responses in the format that are exposed in cm_models package.
3. hecklerd_conf.yaml has new config section that contains the path of CLI.

