### PR TITLE
More integration test automation, plus bug fixes

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -20,18 +20,25 @@ if you use something different, YMMV.
 1.  [Create a GitHub app for testing
     heckler](https://docs.github.com/en/apps/creating-github-apps/creating-github-apps/creating-a-github-app).
 
+    1.  Give it the following permissions (under the repository section):
+
+        * **Administration**: Write (this is not normally needed by heckler,
+        but is needed by the tests.)
+        * **Issues**: Write
+        * **Metadata**: Read
+        * **Commit statuses**: Write
     1.  After the app is created, open its configuration and generate a private
         key in `Private keys` section.
-    2.  Copy the private RSA key to `github-private-key.pem` in the root folder
+    1.  Copy the private RSA key to `github-private-key.pem` in the root folder
         of this repo.
-    3.  Update [`hecklerd_conf.yaml`][] with the following values, now that you
+    1.  Update [`hecklerd_conf.yaml`][] with the following values, now that you
         have them:
 
             * `github_app_slug`
             * `github_app_email`
             * `github_app_id`
 
-2.  [Create the test GitHub
+1.  [Create the test GitHub
     repo](https://docs.github.com/en/get-started/quickstart/create-a-repo),
     probably under your personal org, but that is up to you. (Do _not_,
     however, initialize it with a first commit!)
@@ -41,7 +48,7 @@ if you use something different, YMMV.
         (If you created your repo in an org you are not an admin of, you will
         need to contact your admin to get the installation approved.)
 
-    2.  Update [`hecklerd_conf.yaml`][] with the following values, now that you
+    1.  Update [`hecklerd_conf.yaml`][] with the following values, now that you
         have them:
 
             * `github_app_install_id`
@@ -52,11 +59,11 @@ if you use something different, YMMV.
             * `github_domain` (if doing this on your company's GitHub
                 Enterprise installation instead of public GitHub)
 
-    3.  (If using a personal repo and working with others) [Add any teammates
+    1.  (If using a personal repo and working with others) [Add any teammates
         you want to test with as repo
         collaborators.](https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-access-to-your-personal-repositories/inviting-collaborators-to-a-personal-repository)
 
-    4.  Add your GitHub username (plus any collaborators) as admins in
+    1.  Add your GitHub username (plus any collaborators) as admins in
         [`hecklerd_conf.yaml`][]:
 
         ```yaml
@@ -65,23 +72,23 @@ if you use something different, YMMV.
           - "@your_collaborators_username"
         ```
 
-    5.  Use the [`make_repo`](/make-repo) script to init your test repo and
+    1.  Use the [`make_repo`](/make-repo) script to init your test repo and
         create some commits and release tags.
 
         ```sh
         ./make-repo -u <existing sample github url>
         ```
 
-3.  Build the binaries:
+1.  Build the binaries:
 
     ```sh
     make docker-build
     ```
 
-4.  Run the integration tests!
+1.  Run the integration tests!
 
     1.  Open a new, fresh tmux window
-    2.  Run the `integration-test` make target.
+    1.  Run the `integration-test` make target.
 
         ```sh
         cd docker-compose
@@ -91,38 +98,38 @@ if you use something different, YMMV.
 If you want to know manually start the docker containers for that these tests
 use:
 
-    1.  Start our docker-compose setup, which creates a container that
-        represents the management host (it'll run `hecklerd`), plus three
-        containers that represent members of your server fleet.
+1.  Start our docker-compose setup, which creates a container that
+    represents the management host (it'll run `hecklerd`), plus three
+    containers that represent members of your server fleet.
 
-        ```sh
-        cd docker-compose
-        make run
-        ```
+    ```sh
+    cd docker-compose
+    make run
+    ```
 
-    2.  Set up your `ssh_config` to make accessing the hosts easier.
+1.  Set up your `ssh_config` to make accessing the hosts easier.
 
-        ```sh
-        make ssh-config
-        ```
+    ```sh
+    make ssh-config
+    ```
 
-        You can ssh to them based on the names in the
-        [`docker-compose.yml`](docker-compose/docker-compose.yml) config. The
-        `heckler` container runs `hecklerd` while the rest run `rizzod`, all
-        in systemd units. This means you can get daemon logs from the journal:
+    You can ssh to them based on the names in the
+    [`docker-compose.yml`](docker-compose/docker-compose.yml) config. The
+    `heckler` container runs `hecklerd` while the rest run `rizzod`, all
+    in systemd units. This means you can get daemon logs from the journal:
 
-        ```sh
-        ssh heckler -- journalctl -f -u hecklerd.service
-        ssh statler -- journalctl -f -u rizzod.service
-        ```
+    ```sh
+    ssh heckler -- journalctl -f -u hecklerd.service
+    ssh statler -- journalctl -f -u rizzod.service
+    ```
 
-    3.  Invoke `heckler` or `rizzo` commands by sshing into the containers
-        and running the commands there. For example, you can force hecklerd to
-        start applying from the `v1` tag (like the integration tests do) by
-        running:
+1.  Invoke `heckler` or `rizzo` commands by sshing into the containers
+    and running the commands there. For example, you can force hecklerd to
+    start applying from the `v1` tag (like the integration tests do) by
+    running:
 
-        ```sh
-        ssh heckler -- heckler -rev v1 -force
-        ```
+    ```sh
+    ssh heckler -- heckler -rev v1 -force
+    ```
 
 [`hecklerd_conf.yaml`]: /docs/sample-configs/hecklerd_conf.yaml

--- a/TESTING.md
+++ b/TESTING.md
@@ -13,9 +13,9 @@ make docker-test
 
 ## Integration Test
 
-`docker-compose` and `tmux` are prerequisites for running these tests. We
-use Debian Linux for our development environments, so if you use something
-different, YMMV.
+`docker-compose`, `tmux`, `curl`, `jq`, and `yq`  are prerequisites for
+running these tests. We use Debian Linux for our development environments, so
+if you use something different, YMMV.
 
 1.  [Create a GitHub app for testing
     heckler](https://docs.github.com/en/apps/creating-github-apps/creating-github-apps/creating-a-github-app).

--- a/TESTING.md
+++ b/TESTING.md
@@ -95,8 +95,7 @@ if you use something different, YMMV.
         make integration-test
         ```
 
-If you want to know manually start the docker containers for that these tests
-use:
+If you want to manually start the docker containers that these tests use:
 
 1.  Start our docker-compose setup, which creates a container that
     represents the management host (it'll run `hecklerd`), plus three

--- a/cmd/hecklerd/main.go
+++ b/cmd/hecklerd/main.go
@@ -1601,6 +1601,7 @@ func githubConn(conf *HecklerdConf) (*github.Client, *ghinstallation.Transport, 
 	}
 
 	var privateKeyPath string
+	// TODO: make the default be part of the conf definition
 	if conf.GitHubPrivateKeyPath != "" {
 		privateKeyPath = conf.GitHubPrivateKeyPath
 	} else {

--- a/cmd/hecklerd/main.go
+++ b/cmd/hecklerd/main.go
@@ -2728,7 +2728,8 @@ func fetchRepo(conf *HecklerdConf) (*git.Repository, error) {
 			UpdateFetchhead: true,
 			DownloadTags:    git.DownloadTagsAll,
 		},
-		Bare: true,
+		Bare:           true,
+		CheckoutBranch: conf.RepoBranch,
 	}
 	if conf.GitHubHttpProxy != "" {
 		cloneOptions.ProxyOptions = git.ProxyOptions{

--- a/cmd/rizzod/main.go
+++ b/cmd/rizzod/main.go
@@ -498,6 +498,7 @@ func main() {
 	if err != nil {
 		logger.Fatalf("Error: unable to pull repo, exiting: %v", err)
 	}
+	log.Println("PullBranch Complete")
 
 	grpcServer := grpc.NewServer()
 	rizzoServer := new(rizzoServer)

--- a/docker-compose/Makefile
+++ b/docker-compose/Makefile
@@ -33,7 +33,7 @@ ssh-config:	## Set up your ssh_config to "just work" with the containers
 		echo -e '\n### BEGIN $(SSH_CONFIG_MANAGED_HEADER) ###\nMatch all\nInclude $(THIS_DIR)/node/ssh_configs/ssh_config\n### END $(SSH_CONFIG_MANAGED_HEADER) ###' >> ~/.ssh/config ; \
 		echo Updated ~/.ssh/config to be able to ssh to the test containers. ; \
 	else \
-		echo ~/.ssh/config is already set up. Remove the section starting with '### BEGIN $(SSH_CONFIG_MANAGED_HEADER) ###' if you want to reset it. ; \
+		echo ~/.ssh/config is already set up. It can be reverted by running make clean. ; \
 	fi
 
 .PHONY: ssh-keys
@@ -45,6 +45,7 @@ $(SSH_KEYS):
 .PHONY: clean
 clean: ## Delete generated ssh keys
 	rm -fr node/ssh_configs
+	sed -i -e :a -e '/### BEGIN $(SSH_CONFIG_MANAGED_HEADER) ###/,/### END $(SSH_CONFIG_MANAGED_HEADER) ###/d' -e '/^\n*$$/{$$d;N;ba' -e '}' ~/.ssh/config
 
 .PHONY: integration-test
 integration-test: 	# Run the integration tests from TESTING.md as hands-off as possible

--- a/docker-compose/Makefile
+++ b/docker-compose/Makefile
@@ -1,11 +1,9 @@
 SHELL = /bin/bash
-CONTAINERS = heckler statler waldorf fozzie
 SSH_CONFIG_MANAGED_HEADER := HECKLER INTEGRATION TESTS MANAGED SECTION
 SSH_KEYS := $(shell echo \
 	node/ssh_configs/{heckler,fozzie,statler,waldorf}/root/id_ecdsa{,.pub} \
 	node/ssh_configs/{heckler,fozzie,statler,waldorf}/host/ssh_host_ecdsa_key{,.pub} \
 	)
-SSHABLE_TEST := ssh -o ConnectTimeout=1 -o ConnectionAttempts=1 -o ServerAliveInterval=2
 THIS_DIR := $(realpath $(dir $(abspath $(lastword $(MAKEFILE_LIST)))))
 
 .PHONY: help
@@ -48,59 +46,5 @@ clean: ## Delete generated ssh keys
 	sed -i -e :a -e '/### BEGIN $(SSH_CONFIG_MANAGED_HEADER) ###/,/### END $(SSH_CONFIG_MANAGED_HEADER) ###/d' -e '/^\n*$$/{$$d;N;ba' -e '}' ~/.ssh/config
 
 .PHONY: integration-test
-integration-test: 	# Run the integration tests from TESTING.md as hands-off as possible
-ifndef TMUX
-	$(error These integration tests require you to be in a tmux session)
-endif
-	# these integration tests will open and close a bunch of tmux panes. don't go anywhere while this is running
-	# set up the tmux panes
-	@tmux split-window -h -c $(THIS_DIR)
-	@tmux split-window -v -p 80 -c $(THIS_DIR)
-	@tmux split-window -v -p 75 -c $(THIS_DIR)
-	@tmux split-window -v -p 66 -c $(THIS_DIR)
-	@tmux split-window -v -c $(THIS_DIR)
-	@tmux select-pane -t 0
-	# start the docker containers
-	@tmux send-keys -t 1 "make run" Enter
-	$(MAKE) ssh-config
-	@printf 'Waiting for containers to be sshable...'
-	@for container in $(CONTAINERS) ; do \
-		while ! $(SSHABLE_TEST) $$container -- true >/dev/null 2>&1; do \
-			printf . ; \
-			sleep 5 ; \
-		done ; \
-	done
-	@printf '\n'
-	# tail the logs (so you can debug easier if something goes wrong)
-	@tmux send-keys -t 2 "ssh heckler -- journalctl -f -u hecklerd.service" Enter
-	@tmux send-keys -t 3 "ssh statler -- journalctl -f -u rizzod.service" Enter
-	@tmux send-keys -t 4 "ssh waldorf -- journalctl -f -u rizzod.service" Enter
-	@tmux send-keys -t 5 "ssh fozzie -- journalctl -f -u rizzod.service" Enter
-	# sleep for a while to ensure everything has initialized
-	sleep 10
-	# make heckler apply from the v1 tag
-	@HECKLER_RESULTS=$$(ssh heckler -- heckler -rev v1 -force) ; \
-		echo "$${HECKLER_RESULTS}" ; \
-		if [[ "$${HECKLER_RESULTS}" == 'Applied nodes: (3); Error nodes: (0)' ]] ; then \
-		echo "Success!" ; \
-	else \
-		echo "Failed!" ; \
-	fi
-	# sleep for a while to ensure heckler applies all subsequent tags
-	# TODO try checking its journal logs instead
-	# TODO figure out why it's complaining about HTTP 422 Validation Failed [{Resource:Issue Field:assignees Code:invalid Message:}]
-	sleep 60
-	# TODO run serverspecs here
-	# stop the docker containers and close the panes
-	@tmux send-keys -t 1 C-c
-	@printf 'Waiting for containers to shut down...'
-	@for container in $(CONTAINERS) ; do \
-		while $(SSHABLE_TEST) $$container -- true >/dev/null 2>&1; do \
-			printf . ; \
-			sleep 5 ; \
-		done ; \
-	done
-	@printf '\n'
-	# TODO close all other panes but only if tests succeeded
-	# @tmux kill-pane -a -t 0
-	# TODO figure out a way to raise an error if tests failed; all attempts so far have not been lazy evals and caused problems
+integration-test:	ssh-config	## Run the integration tests from TESTING.md as hands-off as possible
+	./integration-test

--- a/docker-compose/Makefile
+++ b/docker-compose/Makefile
@@ -30,7 +30,7 @@ build-node-image: $(SSH_KEYS) ## Build the node image
 .PHONY: ssh-config
 ssh-config:	## Set up your ssh_config to "just work" with the containers
 	@if ! grep -q '$(SSH_CONFIG_MANAGED_HEADER)' ~/.ssh/config ; then \
-		echo -e '\n### BEGIN $(SSH_CONFIG_MANAGED_HEADER) ###\nMatch all\nInclude $(THIS_DIR)/node/ssh_configs\n### END $(SSH_CONFIG_MANAGED_HEADER) ###' >> ~/.ssh/config ; \
+		echo -e '\n### BEGIN $(SSH_CONFIG_MANAGED_HEADER) ###\nMatch all\nInclude $(THIS_DIR)/node/ssh_configs/ssh_config\n### END $(SSH_CONFIG_MANAGED_HEADER) ###' >> ~/.ssh/config ; \
 		echo Updated ~/.ssh/config to be able to ssh to the test containers. ; \
 	else \
 		echo ~/.ssh/config is already set up. Remove the section starting with '### BEGIN $(SSH_CONFIG_MANAGED_HEADER) ###' if you want to reset it. ; \

--- a/docker-compose/Makefile
+++ b/docker-compose/Makefile
@@ -1,10 +1,11 @@
 SHELL = /bin/bash
+CONTAINERS = heckler statler waldorf fozzie
 SSH_CONFIG_MANAGED_HEADER := HECKLER INTEGRATION TESTS MANAGED SECTION
-SSH_CONFIG_IS_MANAGED := $(shell grep '$(SSH_CONFIG_MANAGED_HEADER)' ~/.ssh/config)
 SSH_KEYS := $(shell echo \
 	node/ssh_configs/{heckler,fozzie,statler,waldorf}/root/id_ecdsa{,.pub} \
 	node/ssh_configs/{heckler,fozzie,statler,waldorf}/host/ssh_host_ecdsa_key{,.pub} \
 	)
+SSHABLE_TEST := ssh -o ConnectTimeout=1 -o ConnectionAttempts=1 -o ServerAliveInterval=2
 THIS_DIR := $(realpath $(dir $(abspath $(lastword $(MAKEFILE_LIST)))))
 
 .PHONY: help
@@ -27,11 +28,13 @@ build-node-image: $(SSH_KEYS) ## Build the node image
 	cd node; docker build . -t heckler-node:latest
 
 .PHONY: ssh-config
-ssh-config:	## Set up your ssh_config to "just work" with the containers (assumes $GOPATH is set to ~/go)
-ifeq ($(SSH_CONFIG_IS_MANAGED),)
-	echo -e '\n### BEGIN $(SSH_CONFIG_MANAGED_HEADER) ###\nMatch all\nInclude heckler/ssh_config\n### END $(SSH_CONFIG_MANAGED_HEADER) ###' >> ~/.ssh/config
-endif
-	ln -sf $(THIS_DIR)/node/ssh_configs $(HOME)/.ssh/heckler
+ssh-config:	## Set up your ssh_config to "just work" with the containers
+	@if ! grep -q '$(SSH_CONFIG_MANAGED_HEADER)' ~/.ssh/config ; then \
+		echo -e '\n### BEGIN $(SSH_CONFIG_MANAGED_HEADER) ###\nMatch all\nInclude $(THIS_DIR)/node/ssh_configs\n### END $(SSH_CONFIG_MANAGED_HEADER) ###' >> ~/.ssh/config ; \
+		echo Updated ~/.ssh/config to be able to ssh to the test containers. ; \
+	else \
+		echo ~/.ssh/config is already set up. Remove the section starting with '### BEGIN $(SSH_CONFIG_MANAGED_HEADER) ###' if you want to reset it. ; \
+	fi
 
 .PHONY: ssh-keys
 ssh-keys: $(SSH_KEYS) ## Generate ssh node keys
@@ -42,3 +45,61 @@ $(SSH_KEYS):
 .PHONY: clean
 clean: ## Delete generated ssh keys
 	rm -fr node/ssh_configs
+
+.PHONY: integration-test
+integration-test: 	# Run the integration tests from TESTING.md as hands-off as possible
+ifndef TMUX
+	$(error These integration tests require you to be in a tmux session)
+endif
+	# these integration tests will open and close a bunch of tmux panes. don't go anywhere while this is running
+	# set up the tmux panes
+	@tmux split-window -h -c $(THIS_DIR)
+	@tmux split-window -v -p 80 -c $(THIS_DIR)
+	@tmux split-window -v -p 75 -c $(THIS_DIR)
+	@tmux split-window -v -p 66 -c $(THIS_DIR)
+	@tmux split-window -v -c $(THIS_DIR)
+	@tmux select-pane -t 0
+	# start the docker containers
+	@tmux send-keys -t 1 "make run" Enter
+	$(MAKE) ssh-config
+	@printf 'Waiting for containers to be sshable...'
+	@for container in $(CONTAINERS) ; do \
+		while ! $(SSHABLE_TEST) $$container -- true >/dev/null 2>&1; do \
+			printf . ; \
+			sleep 5 ; \
+		done ; \
+	done
+	@printf '\n'
+	# tail the logs (so you can debug easier if something goes wrong)
+	@tmux send-keys -t 2 "ssh heckler -- journalctl -f -u hecklerd.service" Enter
+	@tmux send-keys -t 3 "ssh statler -- journalctl -f -u rizzod.service" Enter
+	@tmux send-keys -t 4 "ssh waldorf -- journalctl -f -u rizzod.service" Enter
+	@tmux send-keys -t 5 "ssh fozzie -- journalctl -f -u rizzod.service" Enter
+	# sleep for a while to ensure everything has initialized
+	sleep 10
+	# make heckler apply from the v1 tag
+	@HECKLER_RESULTS=$$(ssh heckler -- heckler -rev v1 -force) ; \
+		echo "$${HECKLER_RESULTS}" ; \
+		if [[ "$${HECKLER_RESULTS}" == 'Applied nodes: (3); Error nodes: (0)' ]] ; then \
+		echo "Success!" ; \
+	else \
+		echo "Failed!" ; \
+	fi
+	# sleep for a while to ensure heckler applies all subsequent tags
+	# TODO try checking its journal logs instead
+	# TODO figure out why it's complaining about HTTP 422 Validation Failed [{Resource:Issue Field:assignees Code:invalid Message:}]
+	sleep 60
+	# TODO run serverspecs here
+	# stop the docker containers and close the panes
+	@tmux send-keys -t 1 C-c
+	@printf 'Waiting for containers to shut down...'
+	@for container in $(CONTAINERS) ; do \
+		while $(SSHABLE_TEST) $$container -- true >/dev/null 2>&1; do \
+			printf . ; \
+			sleep 5 ; \
+		done ; \
+	done
+	@printf '\n'
+	# TODO close all other panes but only if tests succeeded
+	# @tmux kill-pane -a -t 0
+	# TODO figure out a way to raise an error if tests failed; all attempts so far have not been lazy evals and caused problems

--- a/docker-compose/integration-test
+++ b/docker-compose/integration-test
@@ -1,0 +1,121 @@
+#!/bin/bash
+# This script exercises heckler against a "real" GitHub repo. See TESTING.md
+# for more details. Unfortunately, some manual pre-prep and post-run cleanup
+# are required.
+# We highly recommend running this from the Makefile since other make targets
+# are used to reduce code reuse.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+THIS_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+
+# TODO make a non-tmux version of this once we get the ability to do other things like delete issues
+if [[ -z "$TMUX" ]] ; then
+  echo These integration tests require you to be in a tmux session >&2
+  exit 1
+fi
+
+CONTAINERS=(heckler statler waldorf fozzie)
+
+is_sshable() {
+  ssh -o ConnectTimeout=1 -o ConnectionAttempts=1 -o ServerAliveInterval=2 "$1" -- true >/dev/null 2>&1
+}
+
+cleanup() {
+  rc="$?"
+  if [[ -n "${TESTS_FAILED:-}" ]] ; then
+    echo 'The tests failed! We will leave the docker containers and tmux panes open so you can debug.' >&2
+    if [[ "$rc" == 0 ]] ; then
+      ((rc=1))
+    fi
+    return "$rc"
+  fi
+
+  if [[ "$rc" != 0 ]] ; then
+    echo 'This script encountered an error, but the tests did not explicitly fail.' >&2
+    return "$rc"
+  fi
+  echo 'The tests passed! We will clean up the leftovers.'
+
+  echo 'Cleaning up docker containers...'
+  tmux send-keys -t 1 C-c
+
+  printf 'Waiting for containers to shut down...'
+  for container in "${CONTAINERS[@]}" ; do
+    while is_sshable "$container"; do
+      printf .
+      sleep 5
+    done
+  done
+  printf '\nCleaning up tmux panes...\n'
+  tmux kill-pane -a -t 0
+  return "$rc"
+}
+trap cleanup EXIT
+
+# TODO check up front to make sure the repo is initialized as done by make-repo script
+# TODO check up front to make sure commit authors are repo collaborators (also stop using fake authors)
+# TODO use graphql API to delete any existing issues
+
+
+echo "These integration tests will open and close a bunch of tmux panes. don't go anywhere while this is running."
+# set up the tmux panes
+tmux split-window -h -c "${THIS_DIR}"
+tmux split-window -v -p 80 -c "${THIS_DIR}"
+tmux split-window -v -p 75 -c "${THIS_DIR}"
+tmux split-window -v -p 66 -c "${THIS_DIR}"
+tmux split-window -v -c "${THIS_DIR}"
+tmux select-pane -t 0
+
+# start the docker containers
+tmux send-keys -t 1 'make run' Enter
+printf 'Waiting for containers to be sshable...'
+for container in "${CONTAINERS[@]}" ; do \
+  while ! is_sshable "$container"; do \
+    printf . ; \
+    sleep 5 ; \
+  done ; \
+done
+printf '\n'
+
+# tail the logs (so you can debug easier if something goes wrong)
+tmux send-keys -t 2 'ssh heckler -- journalctl -f -u hecklerd.service' Enter
+tmux send-keys -t 3 'ssh statler -- journalctl -f -u rizzod.service' Enter
+tmux send-keys -t 4 'ssh waldorf -- journalctl -f -u rizzod.service' Enter
+tmux send-keys -t 5 'ssh fozzie -- journalctl -f -u rizzod.service' Enter
+echo 'Making sure everything is initialized before making heckler start applying...'
+sleep 10
+
+echo 'Making heckler start applying changes...'
+REV=v1
+HECKLER_RESULTS="$(ssh heckler -- heckler -rev "$REV" -force)"
+echo "${HECKLER_RESULTS}"
+if [[ "${HECKLER_RESULTS}" == 'Applied nodes: (3); Error nodes: (0)' ]] ; then
+  echo "Successfully applied ${REV}! Heckler will now start applying more changes and creating GitHub issues for them."
+else
+  echo "Failed to apply ${REV}! Heckler cannot proceed from here."
+  TESTS_FAILED=true
+fi
+
+printf 'Waiting for heckler to complete creating GitHub issues for all commits...'
+SLEEP_TOTAL=0
+SLEEP_INTERVAL=5
+TIMEOUT=600
+while ! (ssh heckler -- journalctl -u hecklerd.service | grep -q 'No new commits, sleeping') ; do
+  if [[ ${SLEEP_TOTAL} -ge ${TIMEOUT} ]] ; then
+    printf '\nFailure! Did not see heckler say it had no new commits to process after %s seconds.' "$TIMEOUT"
+    TESTS_FAILED=true
+    break
+  fi
+  sleep ${SLEEP_INTERVAL}
+  ((SLEEP_TOTAL+=SLEEP_INTERVAL))
+  printf '.'
+done
+printf '\n'
+
+# TODO run serverspecs here
+
+# TODO check github to see if issues were created and auto-closed as expected

--- a/docker-compose/integration-test
+++ b/docker-compose/integration-test
@@ -298,4 +298,33 @@ printf '\n'
 
 # TODO run serverspecs here
 
-# TODO check github to see if issues were created and auto-closed as expected
+# refresh token since they only last 10 minutes
+APP_TOKEN="$(app_token)"
+# TODO this code should be made more generic, asserting things like whether
+# issues are assigned to milestones that are not after tags that already
+# occurred in their tree, what the contents of each issue's summary message are,
+# is there an issue for every commit that caused a diff, are the issues assigned
+# to the right people, etc. for now, these few simple assertions seem good
+# to catch any egregious errors in heckler's logic.
+# separate API lookups will be necessary to inspect comment contents
+validate_issues_jq_program='
+  def error_preamble: "#" + (.number | tostring) + ": \"" + .title + "\" " ;
+  def is_closed: .state == "closed" // ((. | error_preamble) + "is not closed but should be") ;
+  def has_milestone: has("milestone") // ((. | error_preamble) + "is not part of a milestone") ;
+  def has_assignees: has("assignees") // ((. | error_preamble) + "has no assignees") ;
+  def created_by_heckler: (.user.login == $app_user + "[bot]") // ((. | error_preamble) + "was not created by the heckler test app (" + $app_user + ")") ;
+  # TODO this is not a good approximation; separate API lookup for issue and its comment contents would be necessary
+  def closed_by_heckler: .comments == 1 // ((. | error_preamble) + "was not closed by heckler") ;
+  .items[] | [is_closed, has_milestone, has_assignees, created_by_heckler, closed_by_heckler] | map(select(. != true)) | .[]
+'
+# issues are returned in reverse chronological creation order from this
+# creation order does not seem to correlate to commit order, though. it's jumbled
+issue_problems="$(gh_curl -LsS --get \
+  -H "Authorization: Bearer ${APP_TOKEN}" \
+  --data-urlencode "q=is:issue repo:${GH_REPO_OWNER}/${GH_REPO}" \
+  "https://api.${GH_DOMAIN}/search/issues" \
+  | jq -r --arg app_user "${GH_APP_SLUG}" "${validate_issues_jq_program}" | tee >(cat 1>&2))"
+if [[ -n "${issue_problems}" ]] ; then
+  echo 'The above issues have unexpected state!' >&2
+  TESTS_FAILED=true
+fi

--- a/docker-compose/integration-test
+++ b/docker-compose/integration-test
@@ -58,8 +58,103 @@ trap cleanup EXIT
 
 # TODO check up front to make sure the repo is initialized as done by make-repo script
 # TODO check up front to make sure commit authors are repo collaborators (also stop using fake authors)
-# TODO use graphql API to delete any existing issues
 
+# credit to https://gist.github.com/carestad/bed9cb8140d28fe05e67e15f667d98ad
+# TODO make path to config be configurable via docker run args, i.e., template the .service file
+HECKLERD_CONF="$(readlink -f "${THIS_DIR}"/../doc/sample-configs/hecklerd_conf.yaml)"
+GH_DOMAIN="$(yq -r '.github_domain' "${HECKLERD_CONF}")"
+GH_APP_ID="$(yq -r '.github_app_id' "${HECKLERD_CONF}")"
+GH_INSTALL_ID="$(yq -r '.github_app_install_id' "${HECKLERD_CONF}")"
+GH_APP_SLUG="$(yq -r '.github_app_slug' "${HECKLERD_CONF}")"
+GH_REPO="$(yq -r '.repo' "${HECKLERD_CONF}")"
+GH_REPO_OWNER="$(yq -r '.repo_owner' "${HECKLERD_CONF}")"
+GH_REPO_BRANCH="$(yq -r '.repo_branch' "${HECKLERD_CONF}")"
+# TODO make this configurable too
+GH_APP_PK="$(< "${THIS_DIR}"/../github-private-key.pem)"
+
+# Shared content to use as template
+header='{
+  "alg": "RS256",
+  "typ": "JWT"
+}'
+payload_template='{}'
+
+build_payload() {
+  jq -c \
+    --arg current_time "$(date +%s)" \
+    --arg app_id "${GH_APP_ID}" \
+  '
+  ($current_time | tonumber) as $iat
+  | .iat = $iat
+  | .exp = ($iat + 300)
+  | .iss = ($app_id | tonumber)
+  | .alg = "RS256"
+  ' <<< "${payload_template}" | tr -d '\n'
+}
+
+b64enc() {
+  base64 -w 0 | tr -d '='
+}
+compact_json() {
+  jq -c . | LC_CTYPE=C tr -d '\n'
+}
+rs256_sign() {
+  openssl dgst -binary -sha256 -sign <(printf '%s\n' "$1")
+}
+
+signed_jwt() {
+  local payload sig
+  payload="$(build_payload)" || return
+  signed_content="$(compact_json <<<"${header}" | b64enc).$(compact_json <<<"${payload}" | b64enc)"
+  sig="$(printf '%s' "${signed_content}" | rs256_sign "${GH_APP_PK}" | b64enc)"
+  printf '%s.%s\n' "${signed_content}" "${sig}"
+}
+
+app_token() {
+  curl -LsS -X POST \
+    -H 'Accept: application/vnd.github+json' \
+    -H "Authorization: Bearer $(signed_jwt)"\
+    -H 'X-GitHub-Api-Version: 2022-11-28' \
+    -d '{"repository":"'"${GH_APP_SLUG}"'"}' \
+    "https://api.${GH_DOMAIN}/app/installations/${GH_INSTALL_ID}/access_tokens" \
+    | jq -r '.token'
+}
+
+gql_query_body="
+  query {
+    repository(
+      owner: \\\"${GH_REPO_OWNER}\\\",
+      name: \\\"${GH_REPO}\\\"
+    ) {
+      issues(last: 100) {
+        edges {
+          node {
+            id
+          }
+        }
+      }
+    }
+  }"
+APP_TOKEN="$(app_token)"
+mapfile -t issueIds < <(curl -LsS -X POST \
+  -H "Authorization: Bearer ${APP_TOKEN}" \
+  -d '{"query": "'"${gql_query_body//$'\n'/}"'"}' \
+  "https://${GH_DOMAIN}/api/graphql" \
+  | jq -r '.data.repository.issues.edges[].node.id' \
+)
+
+for issueId in "${issueIds[@]}"; do
+  gql_mutation_body="
+    mutation {
+      deleteIssue(input: {issueId: \\\"${issueId}\\\"}) {
+        clientMutationId
+      }
+    }"
+  curl -LsS -X POST \
+    -H "Authorization: Bearer ${APP_TOKEN}" \
+    -d '{"query": "'"${gql_mutation_body//$'\n'/}"'"}' \
+    "https://${GH_DOMAIN}/api/graphql"
+done
 
 echo "These integration tests will open and close a bunch of tmux panes. don't go anywhere while this is running."
 # set up the tmux panes

--- a/docker-compose/integration-test
+++ b/docker-compose/integration-test
@@ -315,7 +315,7 @@ validate_issues_jq_program='
   def created_by_heckler: (.user.login == $app_user + "[bot]") // ((. | error_preamble) + "was not created by the heckler test app (" + $app_user + ")") ;
   # TODO this is not a good approximation; separate API lookup for issue and its comment contents would be necessary
   def closed_by_heckler: .comments == 1 // ((. | error_preamble) + "was not closed by heckler") ;
-  .items[] | [is_closed, has_milestone, has_assignees, created_by_heckler, closed_by_heckler] | map(select(. != true)) | .[]
+  if .total_count > 0 then .items[] | [is_closed, has_milestone, has_assignees, created_by_heckler, closed_by_heckler] | map(select(. != true)) | .[] else "There are no GitHub Issues, but there should have been some." end
 '
 # issues are returned in reverse chronological creation order from this
 # creation order does not seem to correlate to commit order, though. it's jumbled
@@ -323,8 +323,10 @@ issue_problems="$(gh_curl -LsS --get \
   -H "Authorization: Bearer ${APP_TOKEN}" \
   --data-urlencode "q=is:issue repo:${GH_REPO_OWNER}/${GH_REPO}" \
   "https://api.${GH_DOMAIN}/search/issues" \
-  | jq -r --arg app_user "${GH_APP_SLUG}" "${validate_issues_jq_program}" | tee >(cat 1>&2))"
+  | jq -r --arg app_user "${GH_APP_SLUG}" "${validate_issues_jq_program}" \
+  | sed 's/^/  * /')"
 if [[ -n "${issue_problems}" ]] ; then
-  echo 'The above issues have unexpected state!' >&2
+  echo 'Unexpected state in GitHub Issues after running tests:' >&2
+  echo "${issue_problems}" >&2
   TESTS_FAILED=true
 fi

--- a/docker-compose/integration-test
+++ b/docker-compose/integration-test
@@ -58,7 +58,6 @@ trap cleanup EXIT
 
 # TODO check up front to make sure the repo is initialized as done by make-repo script
 
-# credit to https://gist.github.com/carestad/bed9cb8140d28fe05e67e15f667d98ad
 # TODO make path to config be configurable via docker run args, i.e., template the .service file
 HECKLERD_CONF="$(readlink -f "${THIS_DIR}"/../doc/sample-configs/hecklerd_conf.yaml)"
 GH_DOMAIN="$(yq -r '.github_domain' "${HECKLERD_CONF}")"
@@ -68,9 +67,11 @@ GH_APP_SLUG="$(yq -r '.github_app_slug' "${HECKLERD_CONF}")"
 GH_REPO="$(yq -r '.repo' "${HECKLERD_CONF}")"
 GH_REPO_OWNER="$(yq -r '.repo_owner' "${HECKLERD_CONF}")"
 GH_REPO_BRANCH="$(yq -r '.repo_branch' "${HECKLERD_CONF}")"
-# TODO make this configurable too
-GH_APP_PK="$(< "${THIS_DIR}"/../github-private-key.pem)"
+GH_APP_PK_PATH="$(yq -r --arg default_path "$(readlink -f "${THIS_DIR}"/../github-private-key.pem)" \
+  '.github_private_key_path // $default_path' "${HECKLERD_CONF}")"
+GH_APP_PK="$(< "${GH_APP_PK_PATH}")"
 
+# credit to https://gist.github.com/carestad/bed9cb8140d28fe05e67e15f667d98ad
 # Shared content to use as template
 header='{
   "alg": "RS256",
@@ -119,7 +120,7 @@ gh_curl() {
 app_token() {
   gh_curl -LsS -X POST \
     -H "Authorization: Bearer $(signed_jwt)"\
-    -d '{"repository":"'"${GH_APP_SLUG}"'"}' \
+    -d '{"repository":"'"${GH_REPO}"'"}' \
     "https://api.${GH_DOMAIN}/app/installations/${GH_INSTALL_ID}/access_tokens" \
     | jq -r '.token'
 }
@@ -160,7 +161,7 @@ clean_up_previous_issues() {
     gh_curl -LsS -X POST \
       -H "Authorization: Bearer ${APP_TOKEN}" \
       -d '{"query": "'"${gql_mutation_body//$'\n'/}"'"}' \
-      "https://${GH_DOMAIN}/api/graphql"
+      "https://${GH_DOMAIN}/api/graphql" >/dev/null
   done
 }
 
@@ -225,7 +226,7 @@ ensure_collaborators() {
       -H "Authorization: Bearer ${APP_TOKEN}" \
       "https://api.${GH_DOMAIN}/repos/${GH_REPO_OWNER}/${GH_REPO}/collaborators/${author}" \
     ) ; then
-      echo "${author} (from ${GH_REPO_BRANCH} commit history) is not a collaborator on this repo, please add them before this test can work" >&2
+      echo "${author} (from ${GH_REPO_BRANCH} commit history) is not a collaborator on this repo; please add them before this test can work." >&2
       TESTS_FAILED=true
     fi
   done
@@ -235,10 +236,12 @@ ensure_collaborators() {
 }
 
 # preflight checks/prep
+echo 'Deleting existing issues because we need a clean slate for these tests...'
 clean_up_previous_issues
+echo 'Ensuring that all commit authors are repo collaborators (to prevent 422 errors)...'
 ensure_collaborators
 
-echo "These integration tests will open and close a bunch of tmux panes. don't go anywhere while this is running."
+echo "These integration tests will open and close a bunch of tmux panes. Don't go anywhere while this is running."
 # set up the tmux panes
 tmux split-window -h -c "${THIS_DIR}"
 tmux split-window -v -p 80 -c "${THIS_DIR}"

--- a/docker-compose/integration-test
+++ b/docker-compose/integration-test
@@ -57,7 +57,6 @@ cleanup() {
 trap cleanup EXIT
 
 # TODO check up front to make sure the repo is initialized as done by make-repo script
-# TODO check up front to make sure commit authors are repo collaborators (also stop using fake authors)
 
 # credit to https://gist.github.com/carestad/bed9cb8140d28fe05e67e15f667d98ad
 # TODO make path to config be configurable via docker run args, i.e., template the .service file
@@ -110,51 +109,134 @@ signed_jwt() {
   printf '%s.%s\n' "${signed_content}" "${sig}"
 }
 
-app_token() {
-  curl -LsS -X POST \
+gh_curl() {
+  curl \
     -H 'Accept: application/vnd.github+json' \
-    -H "Authorization: Bearer $(signed_jwt)"\
     -H 'X-GitHub-Api-Version: 2022-11-28' \
+    "${@}"
+}
+
+app_token() {
+  gh_curl -LsS -X POST \
+    -H "Authorization: Bearer $(signed_jwt)"\
     -d '{"repository":"'"${GH_APP_SLUG}"'"}' \
     "https://api.${GH_DOMAIN}/app/installations/${GH_INSTALL_ID}/access_tokens" \
     | jq -r '.token'
 }
 
-gql_query_body="
-  query {
-    repository(
-      owner: \\\"${GH_REPO_OWNER}\\\",
-      name: \\\"${GH_REPO}\\\"
-    ) {
-      issues(last: 100) {
-        edges {
-          node {
-            id
+APP_TOKEN="$(app_token)"
+
+clean_up_previous_issues() {
+  local gql_query_body gql_mutation_body
+  gql_query_body="
+    query {
+      repository(
+        owner: \\\"${GH_REPO_OWNER}\\\",
+        name: \\\"${GH_REPO}\\\"
+      ) {
+        issues(last: 100) {
+          edges {
+            node {
+              id
+            }
           }
         }
       }
-    }
-  }"
-APP_TOKEN="$(app_token)"
-mapfile -t issueIds < <(curl -LsS -X POST \
-  -H "Authorization: Bearer ${APP_TOKEN}" \
-  -d '{"query": "'"${gql_query_body//$'\n'/}"'"}' \
-  "https://${GH_DOMAIN}/api/graphql" \
-  | jq -r '.data.repository.issues.edges[].node.id' \
-)
-
-for issueId in "${issueIds[@]}"; do
-  gql_mutation_body="
-    mutation {
-      deleteIssue(input: {issueId: \\\"${issueId}\\\"}) {
-        clientMutationId
-      }
     }"
-  curl -LsS -X POST \
+  mapfile -t issueIds < <(gh_curl -LsS -X POST \
     -H "Authorization: Bearer ${APP_TOKEN}" \
-    -d '{"query": "'"${gql_mutation_body//$'\n'/}"'"}' \
-    "https://${GH_DOMAIN}/api/graphql"
-done
+    -d '{"query": "'"${gql_query_body//$'\n'/}"'"}' \
+    "https://${GH_DOMAIN}/api/graphql" \
+    | jq -r '.data.repository.issues.edges[].node.id' \
+  )
+
+  for issueId in "${issueIds[@]}"; do
+    gql_mutation_body="
+      mutation {
+        deleteIssue(input: {issueId: \\\"${issueId}\\\"}) {
+          clientMutationId
+        }
+      }"
+    gh_curl -LsS -X POST \
+      -H "Authorization: Bearer ${APP_TOKEN}" \
+      -d '{"query": "'"${gql_mutation_body//$'\n'/}"'"}' \
+      "https://${GH_DOMAIN}/api/graphql"
+  done
+}
+
+# used for functions below
+declare -A email_to_username
+
+lookup_gh_username_from_email() {
+  # this will return the username if the user exists, an empty string if they
+  # don't, and an error if multiple people pop up
+  local email="$1"
+  if ! [[ "${email}" =~ @ ]] ; then
+    # just echo back things that aren't emails
+    echo "${email}"
+    return
+  fi
+  if [[ -v "email_to_username[${email}]" ]] ; then
+    echo "${email_to_username[${email}]}"
+    return
+  fi
+  if [[ "${email#*@}" =~ users.noreply.github.com ]] ; then
+    email_to_username["${email}"]="$(echo "$email" | grep -Po '(\d+\-)??([^@]+)' | cut -d'-' -f2-)"
+  else
+    local curl_res
+    # prevent error from getting set in array
+    curl_res="$(gh_curl -LsS --get \
+      -H "Authorization: Bearer ${APP_TOKEN}" \
+      --data-urlencode "q=${email} in:email" \
+      "https://api.${GH_DOMAIN}/search/users" \
+      | jq -r --arg email "${email}" \
+        'if .total_count > 1 then error("More than one user result for " + $email) else .items[].login end')"
+    email_to_username["${email}"]="${curl_res}"
+  fi
+  echo "${email_to_username[${email}]}"
+}
+
+ensure_collaborators() {
+  declare -A authors
+  local gh_username
+  # get login (username) of author and committer if possible, fall back to email
+  # also parse all emails out of co-authored-bys
+  local jq_program='
+    def login_or_email(f): (f | .login) // (.commit | f | .email);
+    map([login_or_email(.author), login_or_email(.committer), (.commit.message | match("Co-authored-by: [^<]*<([^>]+)>", "g") | .captures[].string)]) | flatten | unique | join("\t")
+  '
+  # turn any emails into usernames, if they can be found
+  for username_or_email in $(gh_curl -LsS \
+    -H "Authorization: Bearer ${APP_TOKEN}" \
+    "https://api.${GH_DOMAIN}/repos/${GH_REPO_OWNER}/${GH_REPO}/commits?sha=${GH_REPO_BRANCH}" \
+    | jq -r "${jq_program}") ; do
+    gh_username="$(lookup_gh_username_from_email "${username_or_email}")"
+    if [[ -z "${gh_username}" ]] ; then
+      # empty value means our search returned no results; they're not a github user probably
+      continue
+    fi
+    # value doesn't really matter, we are just using associative array to avoid having to do `uniq` later
+    authors["${gh_username}"]=""
+  done
+  # ensure all authors are collaborators, otherwise heckler may run into 422
+  # errors when trying to assign them to issues
+  for author in "${!authors[@]}" ; do
+    if ! (gh_curl -Lsf \
+      -H "Authorization: Bearer ${APP_TOKEN}" \
+      "https://api.${GH_DOMAIN}/repos/${GH_REPO_OWNER}/${GH_REPO}/collaborators/${author}" \
+    ) ; then
+      echo "${author} (from ${GH_REPO_BRANCH} commit history) is not a collaborator on this repo, please add them before this test can work" >&2
+      TESTS_FAILED=true
+    fi
+  done
+  if [[ "${TESTS_FAILED:-}" == "true" ]] ; then
+    return 1
+  fi
+}
+
+# preflight checks/prep
+clean_up_previous_issues
+ensure_collaborators
 
 echo "These integration tests will open and close a bunch of tmux panes. don't go anywhere while this is running."
 # set up the tmux panes

--- a/docker-compose/node/gen-ssh-keys
+++ b/docker-compose/node/gen-ssh-keys
@@ -5,6 +5,11 @@
 set -o errexit
 set -o nounset
 
+THIS_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+KNOWN_HOSTS=ssh_known_hosts
+AUTHORIZED_KEYS=authorized_keys
+SSH_CONFIG=ssh_config
+
 function node-ip() {
 	local node="${1}"
 	local config="${2}"
@@ -30,26 +35,29 @@ function gen-node-keys() {
 	pushd "${node}" >/dev/null
 	if ! [[ -f 'host/ssh_host_ecdsa_key' ]]; then
 		if ! ssh-keygen -q -t ecdsa -N '' -f host/ssh_host_ecdsa_key -C "${node}" </dev/null; then
+			echo "Could not generate host key for ${node}">&2
 			return 1
 		fi
 	fi
-	cat host/ssh_host_ecdsa_key.pub >>../ssh_known_hosts
+	if ! node_ip=$(node-ip "${node}" ../../../docker-compose.yml); then
+		echo "Could not determine IP address for ${node}">&2
+		return 1
+	fi
+	printf '%s %s\n' "${node_ip}" "$(cat host/ssh_host_ecdsa_key.pub)" >>../"${KNOWN_HOSTS}"
 	if ! [[ -f 'root/id_ecdsa' ]]; then
 		if ! ssh-keygen -q -t ecdsa -N '' -f root/id_ecdsa -C 'root@'"${node}" </dev/null; then
+			echo "Could not generate root user key for ${node}">&2
 			return 1
 		fi
 	fi
 	cat root/id_ecdsa.pub >>../authorized_keys
-	root_key="$(readlink -f root/id_ecdsa)"
-	if ! node_ip=$(node-ip "${node}" ../../../docker-compose.yml); then
-		return 1
-	fi
-	cat <<-EOF >>../ssh_config
+	cat <<-EOF >>../${SSH_CONFIG}
 		Host ${node}
 		  User root
 		  Hostname ${node_ip}
 		  IdentitiesOnly true
-		  IdentityFile ${root_key}
+		  IdentityFile $(readlink -f root/id_ecdsa)
+		  UserKnownHostsFile $(readlink -f ../"${KNOWN_HOSTS}")
 	EOF
 	popd >/dev/null
 }
@@ -57,23 +65,21 @@ function gen-node-keys() {
 function main() {
 	local -a nodes=("${@}")
 	local base_dir
-	base_dir="$(dirname "${0}")"'/ssh_configs'
+	base_dir="${THIS_DIR}/ssh_configs"
 
 	mkdir -p "${base_dir}"
 	pushd "${base_dir}" >/dev/null
-	rm -f ssh_known_hosts
-	rm -f authorized_keys
-	rm -f ssh_config
+	rm -f "${KNOWN_HOSTS}"
+	rm -f "${AUTHORIZED_KEYS}"
+	rm -f "${SSH_CONFIG}"
 	for node in "${nodes[@]}"; do
 		if ! gen-node-keys "${node}"; then
 			printf 'Error generating keys for %s\n' "${node}"
 			exit 1
 		fi
 	done
-  # TODO maybe let's just say "run make ssh-config"
-	printf '\nAdd the following to your ~/.ssh/config:\n\n'
-	printf 'Match all\n'
-	printf 'Include %s\n\n' "$(readlink -f ssh_config)"
+	ssh-keygen -Hf "${KNOWN_HOSTS}"
+	printf '\nDone. You may run make ssh-config to manually include the generated Host entries to your ssh config..\n'
 	popd >/dev/null
 }
 

--- a/docker-compose/node/gen-ssh-keys
+++ b/docker-compose/node/gen-ssh-keys
@@ -70,6 +70,7 @@ function main() {
 			exit 1
 		fi
 	done
+  # TODO maybe let's just say "run make ssh-config"
 	printf '\nAdd the following to your ~/.ssh/config:\n\n'
 	printf 'Match all\n'
 	printf 'Include %s\n\n' "$(readlink -f ssh_config)"

--- a/internal/gitutil/gitutil.go
+++ b/internal/gitutil/gitutil.go
@@ -239,12 +239,12 @@ func Checkout(rev string, repo *git.Repository) (string, error) {
 
 	commit, err := RevparseToCommit(rev, repo)
 	if err != nil {
-		log.Fatal(err)
+		return "", err
 	}
 
 	tree, err := repo.LookupTree(commit.TreeId())
 	if err != nil {
-		log.Fatal(err)
+		return "", err
 	}
 
 	checkoutOpts := git.CheckoutOpts{


### PR DESCRIPTION
This PR does several things, so here are the broad strokes:

1. Fixes a bug that made it so that heckler did not work on non-default branches
2. Fixes another bug where errors were not bubbling up correctly, making the above very difficult to debug
3. Fixes the ssh key generation and config so that you don't have to deal with `known_hosts` headaches, and also makes `make clean` remove our edits to your `~/.ssh/config` so that you don't have to worry about cruft from our test process lingering in your personal config files
4. Automates the integration tests (or at least, the part that doesn't involve creating a github app and configuring heckler to use it)
5. Adds some assertions to the integration tests so that they're not just "here's how to run heckler, now _you_ figure out whether the output looks right or not!"
6. Documents the software and API permission requirements for the integration tests, broadly speaking
7. Leaves a bunch of TODOs for future improvement ideas for how to make the tests and/or heckler itself more robust