### PR TITLE
Update regexEvalErr to account for syntax errors

### DIFF
--- a/cmd/rizzod/main.go
+++ b/cmd/rizzod/main.go
@@ -293,7 +293,7 @@ func lockComment() (string, error) {
 }
 
 func parseStderr(oid string, stderr string) (*rizzopb.PuppetReport, error) {
-	var regexEvalErr = regexp.MustCompile(`^Error: Evaluation Error:`)
+	var regexEvalErr = regexp.MustCompile(`^Error: (?:Evaluation E|Syntax e)rror`)
 	scanner := bufio.NewScanner(strings.NewReader(stderr))
 	for scanner.Scan() {
 		if regexEvalErr.MatchString(scanner.Text()) {


### PR DESCRIPTION
Puppet can throw either an evaluation error or syntax error depending on where the syntax error is. This catches both kinds.